### PR TITLE
New Feature: Quick Transfer and Removal Guard

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -14,6 +14,7 @@ using AdventureBackpacks.Assets;
 using AdventureBackpacks.Assets.Factories;
 using AdventureBackpacks.Configuration;
 using AdventureBackpacks.Extensions;
+using AdventureBackpacks.Features;
 using BepInEx;
 using HarmonyLib;
 using ItemManager;
@@ -46,6 +47,7 @@ namespace AdventureBackpacks
         public static bool ValheimAwake = false;
         public static bool PerformYardSale = false;
         public static Waiting Waiter;
+        public static ConfigSyncBase ActiveConfig => _config;
         
         //Class Privates
         private static AdventureBackpacks _instance;
@@ -75,6 +77,9 @@ namespace AdventureBackpacks
             PrefabManager.Initalized = true;
 
             Localizer.Waiter.StatusChanged += InitializeBackpacks;
+            
+            //Initialized Features
+            QuickTransfer.FeatureInitialized = true;
             
             //Patch Harmony
             _harmony = new Harmony(Info.Metadata.GUID);

--- a/AdventureBackpacks/AdventureBackpacks.csproj
+++ b/AdventureBackpacks/AdventureBackpacks.csproj
@@ -101,6 +101,7 @@
         <Compile Include="Extensions\InventoryExtensions.cs" />
         <Compile Include="Extensions\ItemDataExtensions.cs" />
         <Compile Include="Extensions\PlayerExtensions.cs" />
+        <Compile Include="Features\QuickTransfer.cs" />
         <Compile Include="Patches\FejdStartup.cs" />
         <Compile Include="Patches\GuiBar.cs" />
         <Compile Include="Patches\Humanoid.cs" />
@@ -120,7 +121,7 @@
       <Content Include="ILRepack.targets" />
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <Target Name="Copy" AfterTargets="ILRepack" Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <Target Name="CopyToDev" AfterTargets="ILRepack">
         <Exec Command="xcopy &quot;$(TargetDir)$(TargetFileName)&quot; &quot;G:\Steam\steamapps\common\Valheim-Dev\BepInEx\plugins\$(ProjectName)\&quot; /q /y /i" />
     </Target>
     <Target Name="Copy" AfterTargets="ILRepack" Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">

--- a/AdventureBackpacks/Assets/Backpacks.cs
+++ b/AdventureBackpacks/Assets/Backpacks.cs
@@ -144,7 +144,7 @@ namespace AdventureBackpacks.Assets
             return true;
         }
 
-        public static void PerformYardSale(Player mLocalPlayer, ItemDrop.ItemData itemData)
+        public static void PerformYardSale(Player mLocalPlayer, ItemDrop.ItemData itemData, bool backpackOnly = false)
         {
             if (itemData.IsBackpack())
             {
@@ -166,14 +166,17 @@ namespace AdventureBackpacks.Assets
                         }
                     }
                     var inventory = backpack.GetInventory();
-                    var playerInventory = mLocalPlayer.GetInventory();
-
                     EmtpyInventory(inventory);
-                    EmtpyInventory(playerInventory);
+
+                    if (!backpackOnly)
+                    {
+                        var playerInventory = mLocalPlayer.GetInventory();
+                        EmtpyInventory(playerInventory);
                     
-                    mLocalPlayer.UnequipAllItems();
+                        mLocalPlayer.UnequipAllItems();
                     
-                    EmtpyInventory(playerInventory);
+                        EmtpyInventory(playerInventory);
+                    }
                 }
             }
             Player.m_localPlayer.Message(MessageHud.MessageType.Center, "$vapok_mod_no_inception5");

--- a/AdventureBackpacks/Features/QuickTransfer.cs
+++ b/AdventureBackpacks/Features/QuickTransfer.cs
@@ -1,0 +1,70 @@
+using AdventureBackpacks.Configuration;
+using AdventureBackpacks.Extensions;
+using BepInEx.Bootstrap;
+using BepInEx.Configuration;
+using HarmonyLib;
+using Vapok.Common.Managers.Configuration;
+using Vapok.Common.Shared;
+
+namespace AdventureBackpacks.Features;
+
+public static class QuickTransfer
+{
+    public static bool FeatureInitialized = false;
+    public static ConfigEntry<bool> EnableQuickTransfer { get; private set;}
+    
+    static QuickTransfer()
+    {
+        ConfigRegistry.Waiter.StatusChanged += (_, _) => RegisterConfiguraitonFile();
+    }
+
+    private static void RegisterConfiguraitonFile()
+    {
+        EnableQuickTransfer = ConfigSyncBase.UnsyncedConfig("Local Config", "Enable Quick Right Click Item Transfer", false,
+            new ConfigDescription("When enabled, can move items to/from player inventory to container, by right clicking.",
+                null,
+                new ConfigurationManagerAttributes { Order = 5 }));
+
+    }
+
+    [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.OnRightClickItem))]
+    static class OnRightClickItemPatch
+    {
+        static bool Prefix(InventoryGui __instance, ItemDrop.ItemData item)
+        {
+            if (Player.m_localPlayer == null || __instance == null || item == null)
+                return false;
+
+            if (__instance.m_currentContainer == null || !__instance.IsContainerOpen() || !EnableQuickTransfer.Value)
+                return true;
+
+            if (Chainloader.PluginInfos.ContainsKey("blumaye.quicktransfer"))
+            {
+                AdventureBackpacks.Log.Warning("blumaye.quicktransfer mod is enabled. Adventure Loot's Quick Transfer disabled.");
+                return true;
+            }
+
+            if (item.m_equiped)
+                return true;
+
+            if (item.IsBackpack())
+                return true;
+            
+            var playerInventory = Player.m_localPlayer.GetInventory();
+            var containerInventory = __instance.m_currentContainer.GetInventory();
+            var itemMoved = true;
+
+            if (playerInventory == null || containerInventory == null)
+                return true;
+
+            if (playerInventory.ContainsItem(item) && containerInventory.HaveEmptySlot())
+                containerInventory.MoveItemToThis(playerInventory, item);
+            else if (containerInventory.ContainsItem(item) && playerInventory.HaveEmptySlot())
+                playerInventory.MoveItemToThis(containerInventory, item);
+            else
+                itemMoved = false;
+
+            return !itemMoved;
+        }
+    }
+}

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,5 +1,15 @@
 # Adventure Backpacks Patchnotes
 
+# 1.5.9.0
+* New Feature Added: Right Click Quick Transfer
+  * This feature, when enabled (disabled by default), allows you to transfer contents between player inventory and containers by right clicking.
+* _**blumaye.quicktransfer**_ Module Compatibility Issue Discovered which could cause loss of backpacks and items in backpacks.
+  * Right Click Quick Transfer Feature meant to replace this mod.
+  * Recommended to remove _**blumaye.quicktransfer**_ mod
+* Added Inception checker on Inventory.AddItem()
+* Added Backpack Removal Guard on Inventory.RemoveItem()
+  * Backpack trashed or removed while containing items should no longer be able to be removed.
+
 # 1.5.8.0
 * Added Frost Resistance as a Configurable Effect.
 * Added Troll Armor Set as a Configurable Effect.

--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ stage of maturity. This includes a backpack progression that will start at Meado
 
 
 # Current Patch Notes
-# 1.5.8.0
-* Added Frost Resistance as a Configurable Effect.
-* Added Troll Armor Set as a Configurable Effect.
-* Completely reworked the Effects System, introducing Factory pattern.
-* Reworked Backpack Inception. The gods have looked down upon you unfavorably.
+# 1.5.9.0
+* New Feature Added: Right Click Quick Transfer
+    * This feature, when enabled (disabled by default), allows you to transfer contents between player inventory and containers by right clicking.
+* _**blumaye.quicktransfer**_ Module Compatibility Issue Discovered which could cause loss of backpacks and items in backpacks.
+    * Right Click Quick Transfer Feature meant to replace this mod.
+    * Recommended to remove _**blumaye.quicktransfer**_ mod
+* Added Inception checker on Inventory.AddItem()
+* Added Backpack Removal Guard on Inventory.RemoveItem()
+    * Backpack trashed or removed while containing items should no longer be able to be removed.
 
 ## 1.5.0.0
 * Initial Release of Adventuring Backpacks introducing 6 New Backpack Prefabs (4 New Models and Designs)


### PR DESCRIPTION
Adding in Quick Transfer and Removal Guard features.

Adds soft incompatibility issue with **blumaye.quicktransfer** mod, which can cause accidental backpack deletion and wipe out contents of the inventory.