### PR TITLE
Release Candidate #4 for 1.5.9 + Updated Translations

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -46,6 +46,7 @@ namespace AdventureBackpacks
         public static ILogIt Log => _log;
         public static bool ValheimAwake = false;
         public static bool PerformYardSale = false;
+        public static bool QuickDropping = false;
         public static Waiting Waiter;
         public static ConfigSyncBase ActiveConfig => _config;
         

--- a/AdventureBackpacks/Assets/Backpacks.cs
+++ b/AdventureBackpacks/Assets/Backpacks.cs
@@ -176,11 +176,16 @@ namespace AdventureBackpacks.Assets
                         mLocalPlayer.UnequipAllItems();
                     
                         EmtpyInventory(playerInventory);
+                        
+                        Player.m_localPlayer.Message(MessageHud.MessageType.Center, "$vapok_mod_no_inception5");
+                        AdventureBackpacks.PerformYardSale = false;
+                    }
+                    else
+                    {
+                        Player.m_localPlayer.Message(MessageHud.MessageType.Center, "$vapok_mod_thor_saves_contents");
                     }
                 }
             }
-            Player.m_localPlayer.Message(MessageHud.MessageType.Center, "$vapok_mod_no_inception5");
-            AdventureBackpacks.PerformYardSale = false;
         }
         
         private static void YardSaleEvent(BackpackItem backpack)

--- a/AdventureBackpacks/Extensions/PlayerExtensions.cs
+++ b/AdventureBackpacks/Extensions/PlayerExtensions.cs
@@ -69,7 +69,9 @@ public static class PlayerExtensions
 
         if (backpack == null)
             return;
-            
+
+        AdventureBackpacks.QuickDropping = true;
+        
         // Unequip and remove backpack from player's back
         // We need to unequip the item BEFORE we drop it, otherwise when we pick it up again the game thinks
         // we had it equipped all along and fails to update player model, resulting in invisible backpack.
@@ -82,5 +84,6 @@ public static class PlayerExtensions
         itemDrop.Save();
 
         InventoryGuiPatches.BackpackIsOpen = false;
+        AdventureBackpacks.QuickDropping = false;
     }
 }

--- a/AdventureBackpacks/Translations/English.json
+++ b/AdventureBackpacks/Translations/English.json
@@ -28,7 +28,9 @@
   "vapok_mod_no_inception3": "You have angered the gods!",
   "vapok_mod_no_inception4": "Sigh... Thor will deal with you soon.",
   "vapok_mod_no_inception5": "Thor has stripped you of your powers!!",
-    
+
+  "vapok_mod_thor_saves_contents": "That backpack had stuff in it. Thor saved it for you.",
+  
   "vapok_mod_useful_backpack": "Your backpack feels useful.",
   "vapok_mod_you_droped_bag": "You dropped a backpack!",
   "vapok_mod_level": "Level",

--- a/Translations/AdventureBackpacks.French.json
+++ b/Translations/AdventureBackpacks.French.json
@@ -31,6 +31,8 @@
   "vapok_mod_no_inception4": "Soupir... Thor s'occupera de vous bientôt.",
   "vapok_mod_no_inception5": "Thor vous a dépouillé de vos pouvoirs !!",
 
+  "vapok_mod_thor_saves_contents": "Ce sac à dos contenait des trucs. Thor l'a gardé pour vous.",
+
   "vapok_mod_useful_backpack": "Votre sac à dos a l'air utile...",
   "vapok_mod_you_droped_bag": "Vous avez laissé tomber votre sac !",
   "vapok_mod_level": "Niveau",

--- a/Translations/AdventureBackpacks.German.json
+++ b/Translations/AdventureBackpacks.German.json
@@ -29,6 +29,8 @@
   "vapok_mod_no_inception4": "Seufz ... Thor wird sich bald um dich kümmern.",
   "vapok_mod_no_inception5": "Thor hat dich deiner Kräfte beraubt!!",
 
+  "vapok_mod_thor_saves_contents": "In diesem Rucksack war was drin. Thor hat es für dich gespeichert.",
+
   "vapok_mod_useful_backpack": "Dein Rucksack fühlt sich nützlich.",
   "vapok_mod_you_droped_bag": "Du hast einen Rucksack fallen lassen!",
   "vapok_mod_level": "Level",

--- a/Translations/AdventureBackpacks.Korean.json
+++ b/Translations/AdventureBackpacks.Korean.json
@@ -29,6 +29,8 @@
    "vapok_mod_no_inception4": "하아... 토르가 곧 당신을 처리할 겁니다.",
    "vapok_mod_no_inception5": "토르가 너의 힘을 빼앗았다!!",
 
+   "vapok_mod_thor_saves_contents": "그 배낭에는 물건이 들어 있었다. 토르가 당신을 위해 저장했습니다.",
+
    "vapok_mod_useful_backpack": "당신의 배낭은 유용하다고 생각합니다.",
    "vapok_mod_you_droped_bag": "배낭을 떨어뜨렸습니다!",
    "vapok_mod_level": "레벨",

--- a/Translations/AdventureBackpacks.Norwegian.json
+++ b/Translations/AdventureBackpacks.Norwegian.json
@@ -29,6 +29,8 @@
   "vapok_mod_no_inception4": "Sukk ... Thor vil ta seg av deg snart.",
   "vapok_mod_no_inception5": "Thor har fratatt deg dine krefter!!",
 
+  "vapok_mod_thor_saves_contents": "Den ryggsekken hadde ting i seg. Thor har lagret det for deg.",
+
   "vapok_mod_useful_backpack": "Din sekk føles nyttig.",
   "vapok_mod_you_droped_bag": "Du slapp en sekk!",
   "vapok_mod_level": "Nivå",

--- a/Translations/AdventureBackpacks.Russian.json
+++ b/Translations/AdventureBackpacks.Russian.json
@@ -28,7 +28,9 @@
   "vapok_mod_no_inception3": "Вы злите богов!",
   "vapok_mod_no_inception4": "Вздыхает... Тор скоро займется вами.",
   "vapok_mod_no_inception5": "Тор лишил вас своих сил!!",
-  
+
+  "vapok_mod_thor_saves_contents": "В этом рюкзаке были вещи. Тор сохранил его для тебя.",
+
   "vapok_mod_useful_backpack": "Ваш рюкзак кажется полезным.",
   "vapok_mod_you_droped_bag": "Ты уронил рюкзак!",
   "vapok_mod_level": "Уровень",

--- a/UnityProjects/vapoksbackpacks/vapoksbackpacks/Assembly-CSharp-Editor.csproj
+++ b/UnityProjects/vapoksbackpacks/vapoksbackpacks/Assembly-CSharp-Editor.csproj
@@ -56,10 +56,10 @@
     <Analyzer Include="C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\Extensions\Microsoft\Visual Studio Tools for Unity\Analyzers\Microsoft.Unity.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Assets\Editor\CreateAssetBundles.cs" />
     <Compile Include="Assets\Editor\AssetRipperPatches\YamlShaderLocker.cs" />
     <Compile Include="Assets\Editor\ValheimExportHelper\WorldGeneratorFix.cs" />
     <Compile Include="Assets\Editor\AssetRipperPatches\YamlShaderPostprocessor.cs" />
+    <Compile Include="Assets\Editor\CreateAssetBundles.cs" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="UnityEngine">


### PR DESCRIPTION
# 1.5.9.0 - Release Candidate 4
* New Feature Added: Right Click Quick Transfer
  * This feature, when enabled (disabled by default), allows you to transfer contents between player inventory and containers by right clicking.
* _**blumaye.quicktransfer**_ Module Compatibility Issue Discovered which could cause loss of backpacks and items in backpacks.
  * Right Click Quick Transfer Feature meant to replace this mod.
  * Recommended to remove _**blumaye.quicktransfer**_ mod
* Added Inception checker on Inventory.AddItem()
* Added Backpack Removal Guard on Inventory.RemoveItem()
  * Backpack trashed or removed while containing items can still be deleted, but contained items will be saved by Thor.