### PR TITLE
Release 1.6.0 - Update to 0.213.4

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -33,8 +33,8 @@ namespace AdventureBackpacks
     {
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
-        private const string _displayName = "AdventureBackpacks";
-        private const string _version = "1.5.9";
+        private const string _displayName = "Adventure Backpacks";
+        private const string _version = "1.6.0";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/AdventureBackpacks.csproj
+++ b/AdventureBackpacks/AdventureBackpacks.csproj
@@ -39,13 +39,13 @@
           <HintPath>..\..\References\BepInEx\5.4.1901\BepInEx\core\0Harmony.dll</HintPath>
         </Reference>
         <Reference Include="assembly_guiutils">
-          <HintPath>..\..\References\Valheim\0.212.9\assembly_guiutils_publicized.dll</HintPath>
+          <HintPath>..\..\References\Valheim\0.213.4\assembly_guiutils_publicized.dll</HintPath>
         </Reference>
         <Reference Include="assembly_utils">
-          <HintPath>..\..\References\Valheim\0.212.9\assembly_utils_publicized.dll</HintPath>
+          <HintPath>..\..\References\Valheim\0.213.4\assembly_utils_publicized.dll</HintPath>
         </Reference>
         <Reference Include="assembly_valheim">
-          <HintPath>..\..\References\Valheim\0.212.9\assembly_valheim_publicized.dll</HintPath>
+          <HintPath>..\..\References\Valheim\0.213.4\assembly_valheim_publicized.dll</HintPath>
         </Reference>
         <Reference Include="BepInEx">
           <HintPath>..\..\References\BepInEx\5.4.1901\BepInEx\core\BepInEx.dll</HintPath>

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -5,9 +5,9 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("AdventureBackpacks")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("A Valheim Mod for adding progression multiple backpacks as an item/utility gear addition.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Vapok Gaming")]
 [assembly: AssemblyProduct("AdventureBackpacks")]
 [assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.9.0")]
-[assembly: AssemblyFileVersion("1.5.9.0")]
+[assembly: AssemblyVersion("1.6.0.0")]
+[assembly: AssemblyFileVersion("1.6.0.0")]

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,5 +1,11 @@
 # Adventure Backpacks Patchnotes
 
+# 1.6.0.0
+* Updating for Valheim Version 0.213.4
+* Right Click Fast Item Transfer Fixes
+  * Stacking Items when bags are full are fixed.
+  * Added vanilla effects on item transfer for crisper feel.
+
 # 1.5.9.0
 * New Feature Added: Right Click Quick Transfer
     * This feature, when enabled (disabled by default), allows you to transfer contents between player inventory and containers by right clicking.

--- a/README.md
+++ b/README.md
@@ -36,15 +36,11 @@ stage of maturity. This includes a backpack progression that will start at Meado
 
 
 # Current Patch Notes
-# 1.5.9.0
-* New Feature Added: Right Click Quick Transfer
-    * This feature, when enabled (disabled by default), allows you to transfer contents between player inventory and containers by right clicking.
-* _**blumaye.quicktransfer**_ Module Compatibility Issue Discovered which could cause loss of backpacks and items in backpacks.
-    * Right Click Quick Transfer Feature meant to replace this mod.
-    * Recommended to remove _**blumaye.quicktransfer**_ mod
-* Added Inception checker on Inventory.AddItem()
-* Added Backpack Removal Guard on Inventory.RemoveItem()
-    * Backpack trashed or removed while containing items can still be deleted, but contained items will be saved by Thor.
+# 1.6.0.0
+* Updating for Valheim Version 0.213.4
+* Right Click Fast Item Transfer Fixes
+    * Stacking Items when bags are full are fixed.
+    * Added vanilla effects on item transfer for crisper feel.
 
 ## 1.5.0.0
 * Initial Release of Adventuring Backpacks introducing 6 New Backpack Prefabs (4 New Models and Designs)

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.5.9",
+  "version_number": "1.6.0",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.0.0 - Update to 0.213.4
* Updating for Valheim Version 0.213.4
* Right Click Fast Item Transfer Fixes
  * Stacking Items when bags are full are fixed.
  * Added vanilla effects on item transfer for crisper feel.