### PR TITLE
Release 1.6.3

### DIFF
--- a/AdventureBackpacks.sln
+++ b/AdventureBackpacks.sln
@@ -18,6 +18,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Translations", "Translation
 		Translations\AdventureBackpacks.Russian.json = Translations\AdventureBackpacks.Russian.json
 		Translations\AdventureBackpacks.Korean.json = Translations\AdventureBackpacks.Korean.json
 		Translations\AdventureBackpacks.Czech.json = Translations\AdventureBackpacks.Czech.json
+		Translations\AdventureBackpacks.Swedish.json = Translations\AdventureBackpacks.Swedish.json
 	EndProjectSection
 EndProject
 Global

--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -35,7 +35,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.2";
+        private const string _version = "1.6.3";
         
         //Interface Properties
         public string PluginId => _pluginId;
@@ -114,7 +114,7 @@ namespace AdventureBackpacks
                 Player.m_localPlayer.QuickDropBackpack();
             }
 
-            InventoryPatches.ProcessItemsAddedCache();
+            InventoryPatches.ProcessItemsAddedQueue();
         }
 
         public void InitializeBackpacks(object send, EventArgs args)

--- a/AdventureBackpacks/AdventureBackpacks.csproj
+++ b/AdventureBackpacks/AdventureBackpacks.csproj
@@ -103,6 +103,7 @@
         <Compile Include="Extensions\ItemDataExtensions.cs" />
         <Compile Include="Extensions\PlayerExtensions.cs" />
         <Compile Include="Features\QuickTransfer.cs" />
+        <Compile Include="Patches\Door.cs" />
         <Compile Include="Patches\FejdStartup.cs" />
         <Compile Include="Patches\GuiBar.cs" />
         <Compile Include="Patches\Humanoid.cs" />

--- a/AdventureBackpacks/Assets/Factories/FactoryBase.cs
+++ b/AdventureBackpacks/Assets/Factories/FactoryBase.cs
@@ -16,5 +16,4 @@ public abstract class FactoryBase
         _logger = logger;
         _config = configs;
     }
-   
 }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackBlackForest.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackBlackForest.cs
@@ -47,18 +47,6 @@ internal class BackpackBlackForest : BackpackItem
     {
         itemData.m_shared.m_movementModifier = SpeedMod.Value/quality;
         
-        switch (quality)
-        {
-            case 1:
-                break;
-            case 2:
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
         ((SE_Stats)statusEffects.Effect).m_addMaxCarryWeight = CarryBonus.Value * quality;
-
     }
 }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMeadows.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMeadows.cs
@@ -44,17 +44,6 @@ internal class BackpackMeadows : BackpackItem
     {
         itemData.m_shared.m_movementModifier = SpeedMod.Value/quality;
         
-        switch (quality)
-        {
-            case 1:
-                break;
-            case 2:
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
         ((SE_Stats)statusEffects.Effect).m_addMaxCarryWeight = CarryBonus.Value * quality;
     }
 }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMistlands.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMistlands.cs
@@ -35,7 +35,7 @@ internal class BackpackMistlands : BackpackItem
     internal sealed override void RegisterConfigSettings()
     {
         RegisterBackpackBiome(BackpackBiomes.Mistlands);
-        RegisterBackpackSize(1,4,4);
+        RegisterBackpackSize(1,8,2);
         RegisterBackpackSize(2,5,4);
         RegisterBackpackSize(3,6,4);
         RegisterBackpackSize(4,7,4);
@@ -51,18 +51,6 @@ internal class BackpackMistlands : BackpackItem
     {
         itemData.m_shared.m_movementModifier = SpeedMod.Value/quality;
         
-        switch (quality)
-        {
-            case 1:
-                break;
-            case 2:
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
         ((SE_Stats)statusEffects.Effect).m_addMaxCarryWeight = CarryBonus.Value * quality;
-
     }
 }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMountains.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMountains.cs
@@ -43,18 +43,6 @@ internal class BackpackMountains : BackpackItem
     {
         itemData.m_shared.m_movementModifier = SpeedMod.Value/quality;
         
-        switch (quality)
-        {
-            case 1:
-                break;
-            case 2:
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
         ((SE_Stats)statusEffects.Effect).m_addMaxCarryWeight = CarryBonus.Value * quality;
-
     }
 }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackPlains.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackPlains.cs
@@ -45,18 +45,6 @@ internal class BackpackPlains : BackpackItem
     {
         itemData.m_shared.m_movementModifier = SpeedMod.Value/quality;
         
-        switch (quality)
-        {
-            case 1:
-                break;
-            case 2:
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
         ((SE_Stats)statusEffects.Effect).m_addMaxCarryWeight = CarryBonus.Value * quality;
-
     }
 }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackSwamp.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackSwamp.cs
@@ -47,18 +47,6 @@ internal class BackpackSwamp : BackpackItem
     {
         itemData.m_shared.m_movementModifier = SpeedMod.Value/quality;
 
-        switch (quality)
-        {
-            case 1:
-                break;
-            case 2:
-                break;
-            case 3:
-                break;
-            default:
-                break;
-        }
         ((SE_Stats)statusEffects.Effect).m_addMaxCarryWeight = CarryBonus.Value * quality;
-
     }
 }

--- a/AdventureBackpacks/Extensions/PlayerExtensions.cs
+++ b/AdventureBackpacks/Extensions/PlayerExtensions.cs
@@ -65,8 +65,6 @@ public static class PlayerExtensions
 
     public static void QuickDropBackpack(this Player player)
     {
-        AdventureBackpacks.Log.Message("Quick dropping backpack.");
-
         if (player == null)
             return;
         
@@ -76,7 +74,7 @@ public static class PlayerExtensions
             return;
 
         AdventureBackpacks.QuickDropping = true;
-        
+        AdventureBackpacks.Log.Message("Quick dropping backpack.");        
         // Unequip and remove backpack from player's back
         // We need to unequip the item BEFORE we drop it, otherwise when we pick it up again the game thinks
         // we had it equipped all along and fails to update player model, resulting in invisible backpack.
@@ -85,7 +83,7 @@ public static class PlayerExtensions
         player.m_inventory.RemoveItem(backpack.Item);
 
         // This drops a copy of the backpack itemDrop.itemData
-        var itemDrop = ItemDrop.DropItem(backpack.Item, 1, player.transform.position + player.transform.forward + player.transform.up, player.transform.rotation);
+        var itemDrop = ItemDrop.DropItem(backpack.Item, 1, player.transform.position - player.transform.up - player.transform.up, player.transform.rotation);
         itemDrop.Save();
 
         InventoryGuiPatches.BackpackIsOpen = false;

--- a/AdventureBackpacks/Patches/Door.cs
+++ b/AdventureBackpacks/Patches/Door.cs
@@ -1,0 +1,23 @@
+using AdventureBackpacks.Extensions;
+using HarmonyLib;
+
+namespace AdventureBackpacks.Patches;
+
+public static class DoorPatches
+{
+    [HarmonyPatch(typeof(Door), nameof(Door.HaveKey))]
+    static class HaveDoorKeyPatch
+    {
+        static void Postfix(Door __instance, ref bool __result)
+        {
+            if (__instance == null || Player.m_localPlayer == null)
+                return;
+
+            if (Player.m_localPlayer.IsBackpackEquipped() && __result == false)
+            {
+                var backpack = Player.m_localPlayer.GetEquippedBackpack();
+                __result = (__instance.m_keyItem == null || backpack.GetInventory().HaveItem(__instance.m_keyItem.m_itemData.m_shared.m_name));
+            }
+        }
+    }
+}

--- a/AdventureBackpacks/Patches/FejdStartup.cs
+++ b/AdventureBackpacks/Patches/FejdStartup.cs
@@ -4,7 +4,6 @@ namespace AdventureBackpacks.Patches;
 
 public class FejdStartupPatches
 {
-
     [HarmonyPatch(typeof(FejdStartup), nameof(FejdStartup.Awake))]
     [HarmonyAfter("org.bepinex.helpers.LocalizationManager")]
     [HarmonyBefore("org.bepinex.helpers.ItemManager")]
@@ -15,5 +14,4 @@ public class FejdStartupPatches
             AdventureBackpacks.Waiter.ValheimIsAwake(true);
         }
     }
-
 }

--- a/AdventureBackpacks/Patches/Humanoid.cs
+++ b/AdventureBackpacks/Patches/Humanoid.cs
@@ -53,8 +53,6 @@ public class HumanoidPatches
             
             if ( Player.m_localPlayer == null && !__result)
                 return;
-            
-            var player = Player.m_localPlayer;
 
             var item = __0;
 

--- a/AdventureBackpacks/Patches/Inventory.cs
+++ b/AdventureBackpacks/Patches/Inventory.cs
@@ -33,14 +33,16 @@ public static class InventoryPatches
     }
     public static void ProcessItemsAddedCache()
     {
-        for (int i = 0; i < ItemsAddedCache.Count; i++)
+        var keys = ItemsAddedCache.Keys.ToArray();
+        for (int i = 0; i < keys.Length; i++)
         {
-            var itemData = ItemsAddedCache.First();
-            TimeSpan timeDifference = DateTime.Now.Subtract(itemData.Value.Item2);
+            var guid = keys[i];
+            var itemData = ItemsAddedCache[guid]; 
+            TimeSpan timeDifference = DateTime.Now.Subtract(itemData.Item2);
             if (timeDifference.TotalSeconds > 0.5)
             {
-                AdventureBackpacks.Log.Debug($"Process Cache Removing {itemData.Key} for Date {itemData.Value.Item2} with a difference of {timeDifference.TotalSeconds} total seconds.");
-                ItemsAddedCache.Remove(itemData.Key);
+                AdventureBackpacks.Log.Debug($"Process Cache Removing {guid} for Date {itemData.Item2} with a difference of {timeDifference.TotalSeconds} total seconds.");
+                ItemsAddedCache.Remove(guid);
             }
         }
     }

--- a/AdventureBackpacks/Patches/Inventory.cs
+++ b/AdventureBackpacks/Patches/Inventory.cs
@@ -11,23 +11,23 @@ namespace AdventureBackpacks.Patches;
 
 public static class InventoryPatches
 {
-    private static bool _movingItemBetweenContainers = false;
-    private static bool _droppingOutside = false;
+    private static bool _movingItemBetweenContainers;
+    private static bool _droppingOutside;
 
-    public static Queue<KeyValuePair<ItemDrop.ItemData,DateTime>> ItemsAddedQueue = new();
+    private static readonly Queue<KeyValuePair<ItemDrop.ItemData,DateTime>> ItemsAddedQueue = new();
 
-    private static bool TryGetItemFromQueue(this ItemDrop.ItemData item)
+    private static bool IsItemFromQueue(this ItemDrop.ItemData item)
     {
         if (ItemsAddedQueue.Any(x => x.Key.Equals(item)))
         {
-            AdventureBackpacks.Log.Debug($"Guid {item.m_shared.m_name} Found!");
+            AdventureBackpacks.Log.Debug($"Item {item.m_shared.m_name} Found!");
             return true;
         }
         AdventureBackpacks.Log.Debug($"Item Not Found!");
         return false;
     }
 
-    public static void ProcessItemsAddedCache()
+    public static void ProcessItemsAddedQueue()
     {
         while (ItemsAddedQueue.Any() && DateTime.Now.Subtract(ItemsAddedQueue.Peek().Value).TotalSeconds > 0.5)
         {
@@ -96,12 +96,10 @@ public static class InventoryPatches
     [HarmonyPriority(Priority.First)]
     static class RemoveItem1Patch
     {
-        static bool Prefix(Inventory __instance, ItemDrop.ItemData item)
+        static void Prefix(Inventory __instance, ItemDrop.ItemData item)
         {
-            if (item == null)
-                return false;
-
-            return RemoveItemPrefix(__instance, item);
+            if (item != null && __instance != null)
+                RemoveItemPrefix(__instance, item);
         }
     }
 
@@ -109,12 +107,10 @@ public static class InventoryPatches
     [HarmonyPriority(Priority.First)]
     static class RemoveItem2Patch
     {
-        static bool Prefix(Inventory __instance, ItemDrop.ItemData item)
+        static void Prefix(Inventory __instance, ItemDrop.ItemData item)
         {
-            if (item == null)
-                return false;
-
-            return RemoveItemPrefix(__instance, item);
+            if (item != null && __instance != null)
+                RemoveItemPrefix(__instance, item);
         }
     }
 
@@ -122,41 +118,39 @@ public static class InventoryPatches
     [HarmonyPriority(Priority.First)]
     static class RemoveItem3Patch
     {
-        static bool Prefix(Inventory __instance, ItemDrop.ItemData item)
+        static void Prefix(Inventory __instance, ItemDrop.ItemData item)
         {
-            if (item == null)
-                return false;
-
-            return RemoveItemPrefix(__instance, item);
+            if (item != null && __instance != null)
+                RemoveItemPrefix(__instance, item);
         }
     }
 
     
-    private static bool RemoveItemPrefix(Inventory __instance, ItemDrop.ItemData item)
+    private static void RemoveItemPrefix(Inventory __instance, ItemDrop.ItemData item)
     {
         if (__instance == null || Player.m_localPlayer == null)
-            return true;
+            return;
         
         if (_movingItemBetweenContainers || _droppingOutside)
         {
-            return true;
+            return;
         }
         
         if (AdventureBackpacks.PerformYardSale || AdventureBackpacks.QuickDropping)
-            return true;
+            return;
             
         if (item.TryGetBackpackItem(out var backpackItem))
         {
             AdventureBackpacks.Log.Debug($"Checking for Backpack {item.m_shared.m_name}");
-            if (TryGetItemFromQueue(item))
+            if (IsItemFromQueue(item))
             {
                 AdventureBackpacks.Log.Debug($"Exiting RemoveItem for {item.m_shared.m_name}");
-                return true;
+                return;
             }
             
             var backpack = item.Data().Get<BackpackComponent>();
             if (backpack == null)
-                return true;
+                return;
             var inventory = backpack.GetInventory();
                 
             if (inventory != null && inventory.m_inventory.Count > 0)
@@ -164,8 +158,6 @@ public static class InventoryPatches
                 Backpacks.PerformYardSale(Player.m_localPlayer, item, true);
             }
         }
-
-        return true;
     }
     
     [HarmonyPatch(typeof(Inventory), nameof(Inventory.AddItem), new[] { typeof(ItemDrop.ItemData) })]
@@ -191,7 +183,7 @@ public static class InventoryPatches
             
                 return noInception;
             }
-
+            
             return true;
         }
     }
@@ -202,7 +194,8 @@ public static class InventoryPatches
     {
         static bool Prefix(InventoryGrid __instance, Inventory fromInventory, ItemDrop.ItemData item, int amount, Vector2i pos)
         {
-            ItemDrop.ItemData itemAt = __instance.m_inventory.GetItemAt(pos.x, pos.y);
+            var itemAt = __instance.m_inventory.GetItemAt(pos.x, pos.y);
+            
             if (itemAt == item)
                 return true;
             if (itemAt == null || !(itemAt.m_shared.m_name != item.m_shared.m_name) && (item.m_shared.m_maxQuality <= 1 || itemAt.m_quality == item.m_quality) && itemAt.m_shared.m_maxStackSize != 1 || item.m_stack != amount)
@@ -313,7 +306,7 @@ public static class InventoryPatches
             
             var player = Player.m_localPlayer;
             
-            if (__instance.GetName().Contains("$vapok_mod_level"))
+            if (__instance.IsBackPackInventory())
             {
                 // When the equipped backpack inventory total weight is updated, the player inventory total weight should also be updated.
                 if (player)
@@ -344,7 +337,7 @@ public static class InventoryPatches
                         if (item == null)
                             continue;
                         
-                        if (item.TryGetBackpackItem(out var backpack))
+                        if (item.IsBackpack())
                         {
                             if (!item.Data().GetOrCreate<BackpackComponent>().GetInventory().IsTeleportable())
                             {

--- a/AdventureBackpacks/Patches/InventoryGui.cs
+++ b/AdventureBackpacks/Patches/InventoryGui.cs
@@ -12,26 +12,13 @@ namespace AdventureBackpacks.Patches;
 
 internal static class InventoryGuiPatches
 {
-    public static bool BackpackIsOpen = false;
-    public static bool BackpackIsOpening = false;
+    public static bool BackpackIsOpen;
+    public static bool BackpackIsOpening;
     public static bool BackpackEquipped = false;
-    
-    //Upgrade Variables
-    public static bool DoingUpgrade = false;
 
     [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.DoCrafting))]
     static class InventoryGuiDoCraftingPrefix
     {
-        static void Prefix(InventoryGui __instance)
-        {
-            if (__instance == null)
-                return;
-            if (__instance.m_craftUpgradeItem != null || (__instance.m_craftRecipe != null && __instance.m_craftRecipe.m_item != null))
-            {
-                DoingUpgrade = true;
-            }
-        }
-
         static void Postfix(InventoryGui __instance)
         {
             if (__instance.m_craftUpgradeItem != null && __instance.m_craftUpgradeItem.IsBackpack())
@@ -40,9 +27,7 @@ internal static class InventoryGuiPatches
                 backpack?.Load();
                 Player.m_localPlayer.UpdateEquipmentStatusEffects();
             }
-            DoingUpgrade = false;
         }
-        
     }
     
     [HarmonyPatch(typeof(InventoryGui), nameof(InventoryGui.OnSelectedItem))]

--- a/AdventureBackpacks/Patches/ItemDrop.cs
+++ b/AdventureBackpacks/Patches/ItemDrop.cs
@@ -25,7 +25,7 @@ public class ItemDropPatches
                 if (__instance.TryGetBackpackItem(out var backpack))
                 {
                     
-                    // If the item in GetWeight() is a backpack, and it has been Extended(), call GetTotalWeight() on its Inventory.
+                    // If the item in GetWeight() is a backpack, call GetTotalWeight() on its Inventory.
                     // Note that GetTotalWeight() just returns a the value of m_totalWeight, and doesn't do any calculation on its own.
                     // If the Inventory has been changed at any point, it calls UpdateTotalWeight(), which should ensure that its m_totalWeight is accurate.
                     var inventoryWeight = __instance.Data().GetOrCreate<BackpackComponent>().GetInventory()?.GetTotalWeight() ?? 0;

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.2.0")]
-[assembly: AssemblyFileVersion("1.6.2.0")]
+[assembly: AssemblyVersion("1.6.3.0")]
+[assembly: AssemblyFileVersion("1.6.3.0")]

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,13 +1,22 @@
 # Adventure Backpacks Patchnotes
 
+# 1.6.3.0 - Key/Door Detection - Performance Tuning
+* Keys stored in **Equipped Backpack** are detected for purposes of entering through doors. (e.g. Swamp Key opens Crypts).
+  * Keys stored in backpacks NOT equipped, will be hidden from detection.
+* Improved Backpack Protection Guards and Mod Compatibility
+  * Ensuring that mods are handling your backpacks appropriately to prevent item loss and/or item dupping.
+* Includes updated translations for Czech and Korean, as well as adds support for Swedish translation
+* Changed Default Size of Level 1 Explorer's Wisppack from 4x4 (16 Slot Inventory) to a 8x2 (16 Slot Inventory)
+* Enhanced and Expanded Readme File
+
 # 1.6.2.0 - Bug Fixes and Mod Compatibility
-* The last udpate introduced a Language Translation issue where it stopped loading Translation files. 
+* The last update introduced a Language Translation issue where it stopped loading Translation files. 
   * This has been resolved. Apologies to my non-english friends!
 * Adding in Language Translation Support for Czech
 * Additional Mod Compatibility changes.
   * Quick Stack Store would cause Thor to empty backpacks when using the Take All / Store All commands.
     * This has been fixed.
-    * This **might** also fix an item dupping issue that is being experienced with Multi-User-Chests (not validated yet)
+    * This resolves an item dupping issue that is being experienced with Multi-User-Chests (not validated yet)
 * This update also attempts to fix the Grid Not Displaying on Level 1 Wisppacks when opened on initial load of Valheim.
 
 # 1.6.1.0 - Module Compatibility on Right Click Quick Transfer

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -7,6 +7,7 @@
   * Ensuring that mods are handling your backpacks appropriately to prevent item loss and/or item dupping.
 * Includes updated translations for Czech and Korean, as well as adds support for Swedish translation
 * Changed Default Size of Level 1 Explorer's Wisppack from 4x4 (16 Slot Inventory) to a 8x2 (16 Slot Inventory)
+* Quick Dropping (Outward Mode) now drops behind the Player running.
 * Enhanced and Expanded Readme File
 
 # 1.6.2.0 - Bug Fixes and Mod Compatibility

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
 
 ## Features of Backpacks
 * Each Backpack Biome can be fully configured for progression.
+  * Configure Sizing
+    * Each Quality Level of Backpack can have a different inventory grid size. Simply adjust the width and height in configuration for each quality level.
   * Configure Recipes
     * Default Recipes can be found in the configuration.
   * Configure Drops
@@ -43,6 +45,11 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
     * Drops are **DISABLED** by default. (as of version 1.6.3)
   * Configure Effects
     * Each Backpack Biome can be configured for any number of effects that are included in this mod.  There is nothing hardcoded about the effects.
+  * Configure Carry Weight Maximum
+    * Allows configuration for adjusting the additional carry weight allowed, per level of backpack.
+  * Configure Speed Modification
+    * Configure Speed Modification (slowness).
+      * Upon each quality upgrade of backpack, speed modification is reduced (never eliminated).
 * Backpack Inventory Protection Guard
   * Every backpack inventory is specially handled by Thor himself and is monitored for any interactions that might otherwise harm the existence of items in your backpacks.
   * Backpacks in Backpacks is not allowed and the only feature that is not configurable. This is how the Allfather dreamt of it.
@@ -64,6 +71,9 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
 * Optional Right Click Quick Transfer (Fast Item Transfer)
   * Allows single right-click transfer of an item/stack of items between Player Inventory and any Open Container
   * This is the same functionality that's available as the stand-alone mod **Fast Item Transfer**
+* Outward Run Away Mode
+  * Pressing the Quick Drop keybind (default is `Y`), will immediately release the equipped backpack and drop it behind the player on the ground.
+  * This feature is optional, and is disabled out of the box.
        
 
 ## Effects Used In This Mod

--- a/README.md
+++ b/README.md
@@ -5,25 +5,25 @@ Starting as a wee Viking, rummaging through the tranquil fields of the Meadows, 
 that you think will eventually lead to a more meaningful destiny.  From Deer Hide capes and beyond, you'll soon 
 learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye wanderer of the wanders! 
 
-## Roadmap
-* **v1.5.0 - Adventure Awaits - Revamped all backpacks to be upgradable and offer new perks as upgrades happen. and offer backpacks at each 
-stage of maturity. This includes a backpack progression that will start at Meadows and continue through Mistlands**
-* v2.0.0 - To be determined!
+---
 
-# How to Use Adventure Backpacks
+## How to Use Adventure Backpacks
 * Play Valheim as you would As you craft items and explore materials you will learn new recipes for Adventuring Backpacks
 * The default hotkey is `I` to open the equipped backpack.
 * Each backpack is completely different in form, function, and size.  Upgrading backpacks will unlock additional features depending on the progresion that backpack is intended to be used with.
 * Check the Configuration for ALL the different ways that you can modify these packs.
 
-## Effects Used In This Mod
-* This mod utilizes the following effects depending on backpack and quality level:
-  * Carry Weight Modifications
-  * Speed Modifications
-  * Frost Resistence
-  * Waterproof
-  * Slow Fall
-  * Demister  (a future upgrade will provide a toggle key to turn off the Demister Ball)
+## How To Install Adventure Backpacks
+* Install Adventure Backpacks into it's own FOLDER inside of the `BepInEx/plugins` folder.
+  * Create a folder called `Translations` and ensure all Translation files are stored in there.
+    * Translations files should be named `AdventureBackpacks.<language key>.json`
+* Adventure Backpacks is a client-side and server-side mod.
+  * If using on Dedicated Servers:
+    * Configuration Lock and Sync is available and disabled by default.
+      * Enabling Locked and Synced Configs will require server restart.
+      * All other settings will be synced to connected clients, and server configs will be enforced.
+
+---
 
 ## Gear Introduced In This Mod
 * The 6 new backpacks are:
@@ -34,43 +34,85 @@ stage of maturity. This includes a backpack progression that will start at Meado
     * **Lox Hide Knappsack** - _An adventuring backpack made from extremely durable lox hide._
     * **Explorers Wisppack** - _A finely crafted, mystical backpack. Complete with it's own Box of Holding. No one is quite sure how it works._
 
+## Features of Backpacks
+* Each Backpack Biome can be fully configured for progression.
+  * Configure Recipes
+    * Default Recipes can be found in the configuration.
+  * Configure Drops
+    * Creatures and Drop Rates can be fully customized.
+    * Drops are **DISABLED** by default. (as of version 1.6.3)
+  * Configure Effects
+    * Each Backpack Biome can be configured for any number of effects that are included in this mod.  There is nothing hardcoded about the effects.
+* Backpack Inventory Protection Guard
+  * Every backpack inventory is specially handled by Thor himself and is monitored for any interactions that might otherwise harm the existence of items in your backpacks.
+  * Backpacks in Backpacks is not allowed and the only feature that is not configurable. This is how the Allfather dreamt of it.
+  * Current verified list of Compatible Inventory Mods:
+    * Quick Stack Store
+    * Fast Item Transfer (function is included in Backpacks)
+    * Multi-User-Chest
+* Backpack Monitoring System
+  * Features complete support for Portal Technology to ensure no undesired items are hiding inside of backpacks in Player Inventory.
+    * This feature will work with any Portal/Teleportation Mod that uses the `Inventory.IsTeleportable()` method.
+      * Protip: Do not use `Humanoid.IsTeleportable()` as it won't respect backpack inventory.
+      * Current List of verified Portal Compatibility:
+        * Valheim Vanilla Portals
+        * Advanced Portals
+        * AnyPortal
+        * XPortal
+  * Keys stored in **Equipped Backpack** will active appropriate locked doors without having to move the key to Player inventory.
+    * Swamp Key for Crypts
+* Optional Right Click Quick Transfer (Fast Item Transfer)
+  * Allows single right-click transfer of an item/stack of items between Player Inventory and any Open Container
+  * This is the same functionality that's available as the stand-alone mod **Fast Item Transfer**
+       
 
-# Current Patch Notes
-# 1.6.2.0 - Bug Fixes and Mod Compatibility
-* The last udpate introduced a Language Translation issue where it stopped loading Translation files.
-    * This has been resolved. Apologies to my non-english friends!
-* Additional Mod Compatibility changes.
-    * Quick Stack Store would cause Thor to empty backpacks when using the Take All / Store All commands.
-        * This has been fixed.
-        * This **might** also fix an item dupping issue that is being experienced with Multi-User-Chests (not validated yet)
-* This update also attempts to fix the Grid Not Displaying on Level 1 Wisppacks when opened on initial load of Valheim.
+## Effects Used In This Mod
+* This mod utilizes the following effects depending on backpack and quality level:
+  * Carry Weight Modifications
+  * Speed Modifications
+  * Frost Resistance
+  * Cold Resistance
+  * Troll Armor Set
+  * Waterproof
+  * Slow Fall
+  * Demister
 
-## 1.5.0.0
-* Initial Release of Adventuring Backpacks introducing 6 New Backpack Prefabs (4 New Models and Designs)
-    * The original two prefabs, have been identified as legacy items, that can no longer be built.  They will live on in your inventory as "Old".  Functionally, they'll exist as they have been.  But they aren't craftable, nor are they upgradeable.  (though they are configurable).
-    * The 6 new Prefabs, introduce the 6 new bags that are intended to be used as progression bags.
-    * The mod author would prefer that folks adventure in the world of Valheim and stumble across what it takes to craft the assortment of bags, however, those with less adventuring desires, may look at the configuration, where I do expose all of the recipes and what you have to touch in order to gain the recipes.  Yes, this also means that all of the bags are configurable for those that pack to the beat of a different drum.
-    * The 6 new backpacks are:
-        * **Satchel** - _A small backpack capable of holding things._
-        * **Rugged Backpack**  - _A rugged backpack, complete with buckles and fine leather straps._
-        * **Bloodbag Wetpack** - _A durable backpack sealed using waterproof blood bags._
-        * **Arctic Sherpa Pack** - _An arctic backpack, fit for long treks through the mountains._
-        * **Lox Hide Knappsack** - _An adventuring backpack made from extremely durable lox hide._
-        * **Explorers Wisppack** - _A finely crafted, mystical backpack. Complete with it's own Box of Holding. No one is quite sure how it works._
-    * Greatly Expanded and 100% completely configurable settings.
+## Currently Available Translations
+* Czech / čeština
+* English
+* French / Français
+* German / Deutsch
+* Korean / 한국인
+* Norwegian / norsk
+* Russian / Русский
+* Swedish / svenska
+* *Don't see your language, I'm looking for submissions for additional languages. Please find me on Discord (see link below) or submit a Pull Request!*
+
+## Current Patch Notes
+[Adventure Backpack Patchnotes](https://github.com/Vapok/AdventureBackpacks/blob/main/PATCHNOTES.md) 
 
 ## Compatible Mods (Verified)
 * Epic Loot 0.9.3+
+  * Check out our Discord to get Epic Loot Patches for Dropping backpacks as Epic Loot!
 * Equipment and Quickslots
 * Advanced Portals
 * AnyPortal
+* XPortal
 * Project Auga
-* _There's probably a ton of others. We are friendly to most mods. If you see a conflict though, let me know!_
+* Quick Stack Store
+* Auto Split Stack
+* Multi-User-Chests
+* Fast Item Transfer
+* Equipment and Quick Slots
+* _There's probably a ton of others. This mod is friendly to most mods. If you see a conflict though, let me know!_
 
 ## Incompatible Mods
-* JotunnBackpacks - (This will convert bags, but safe to revert back to JotunnBackpacks)
+* JotunnBackpacks
+  * This will convert bags, but safe to revert back to JotunnBackpacks.
 
-### Mod Author Details
+---
+
+### About Vapok Gaming
 ![Vapok Gaming](https://avatars.githubusercontent.com/u/1264136?s=180&v=4)
 
 Author: [Vapok](https://github.com/Vapok)
@@ -80,5 +122,3 @@ Source: [Github](https://github.com/Vapok/AdventureBackpacks)
 Discord: [Vapok's Mod's Community](https://discord.gg/5YAJkRFBXt)
 
 Patch notes: [Github Patchnotes](https://github.com/Vapok/AdventureBackpacks/blob/main/PATCHNOTES.md)
-
-

--- a/Translations/AdventureBackpacks.Czech.json
+++ b/Translations/AdventureBackpacks.Czech.json
@@ -17,11 +17,11 @@
   "vapok_mod_item_backpack_mistlands": "Mystický batoh",
   "vapok_mod_item_backpack_mistlands_description": "Precizně zpracovaný mystický batoh. S vlastní krabičkou na drobnosti. Nikdo si není jistý, jak funguje.",
 
-  "vapok_mod_item_rugged_backpack": "2 Kožený batoh",
-  "vapok_mod_item_rugged_backpack_description": "2 Kožený batoh s přezkami a jemnými koženými řemínky.",
+  "vapok_mod_item_rugged_backpack": "Kožený batoh",
+  "vapok_mod_item_rugged_backpack_description": "Kožený batoh s přezkami a jemnými koženými řemínky.",
 
-  "vapok_mod_item_arctic_backpack": "2 Zimní batoh",
-  "vapok_mod_item_arctic_backpack_description": "2 Zimní batoh vhodný na dlouhé túry po horách.",
+  "vapok_mod_item_arctic_backpack": "Zimní batoh",
+  "vapok_mod_item_arctic_backpack_description": "Zimní batoh vhodný na dlouhé túry po horách.",
 
   "vapok_mod_no_inception1": "Nepokoušej bohy.",
   "vapok_mod_no_inception2": "Byl jsi varován.",

--- a/Translations/AdventureBackpacks.Korean.json
+++ b/Translations/AdventureBackpacks.Korean.json
@@ -1,37 +1,37 @@
 {
-   "vapok_mod_item_backpack_meadows": "가방",
+   "vapok_mod_item_backpack_meadows": "작은 배낭",
    "vapok_mod_item_backpack_meadows_description": "물건을 담을 수 있는 작은 배낭입니다.",
  
    "vapok_mod_item_backpack_blackforest": "견고한 배낭",
-   "vapok_mod_item_backpack_blackforest_description": "버클과 고급 가죽 끈이 있는 견고한 배낭입니다.",
+   "vapok_mod_item_backpack_blackforest_description": "버클형 타입으로 고급가죽이 사용되었습니다. 튼튼해 보입니다.",
  
-   "vapok_mod_item_backpack_swamp": "피 주머니 웻팩",
-   "vapok_mod_item_backpack_swamp_description": "방수 혈액 주머니로 봉인된 내구성이 뛰어난 배낭입니다.",
+   "vapok_mod_item_backpack_swamp": "혈액이 묻은 배낭",
+   "vapok_mod_item_backpack_swamp_description": "혈액 주머니를 이용하여 제작된 방수형 배낭입니다.",
  
-   "vapok_mod_item_backpack_mountains": "북극 셰르파 팩",
-   "vapok_mod_item_backpack_mountains_description": "산을 통과하는 긴 트레킹에 적합한 북극 배낭입니다.",
+   "vapok_mod_item_backpack_mountains": "북극 셰르파 배낭",
+   "vapok_mod_item_backpack_mountains_description": "추위를 견딜수 있습니다. 산을 통과하는데 적합한 배낭입니다.",
  
-   "vapok_mod_item_backpack_plains": "록스 가죽 배낭",
-   "vapok_mod_item_backpack_plains_description": "매우 튼튼한 록스 가죽으로 만든 모험용 배낭입니다.",
+   "vapok_mod_item_backpack_plains": "록스가죽 배낭",
+   "vapok_mod_item_backpack_plains_description": "록스가죽보다 더 튼튼한 가죽은 없습니다. 이시대의 모험가에게 최고의 선물입니다.",
  
-   "vapok_mod_item_backpack_mistlands": "위스팩 탐험가",
-   "vapok_mod_item_backpack_mistlands_description": "정교하게 제작된 신비로운 백팩입니다. 자체 보관함과 함께 완성됩니다. 어떻게 작동하는지 아무도 모릅니다.",
+   "vapok_mod_item_backpack_mistlands": "위습 탐험가의 배낭",
+   "vapok_mod_item_backpack_mistlands_description": "신들이 감탄합니다! 매우 정교하게 만들어졌습니다. 자체 보관함과 함께 완성됩니다. 어떻게 작동하는지 아무도 모릅니다.",
  
-   "vapok_mod_item_rugged_backpack": "오래된 투박한 배낭",
-   "vapok_mod_item_rugged_backpack_description": "버클과 고급 가죽 끈이 있는 견고한 배낭입니다.",
+   "vapok_mod_item_rugged_backpack": "오래되고 투박한 배낭",
+   "vapok_mod_item_rugged_backpack_description": "버클형 타입으로 고급가죽이 사용되었습니다. 튼튼해 보입니다.",
  
-   "vapok_mod_item_arctic_backpack": "오래된 북극 배낭",
-   "vapok_mod_item_arctic_backpack_description": "산을 통과하는 긴 트레킹에 적합한 북극 배낭입니다.",
+   "vapok_mod_item_arctic_backpack": "북극 트레킹 배낭",
+   "vapok_mod_item_arctic_backpack_description": "추위를 견딜수 있습니다. 산을 통과하는데 적합한 배낭입니다.",
   
    "vapok_mod_no_inception1": "신들을 화나게 하지 마십시오.",
-   "vapok_mod_no_inception2": "당신은 경고를 받았습니다.",
-   "vapok_mod_no_inception3": "당신은 신들을 화나게 했습니다!",
-   "vapok_mod_no_inception4": "하아... 토르가 곧 당신을 처리할 겁니다.",
-   "vapok_mod_no_inception5": "토르가 너의 힘을 빼앗았다!!",
+   "vapok_mod_no_inception2": "당신은 경고 받았습니다.",
+   "vapok_mod_no_inception3": "신들이 분노합니다!",
+   "vapok_mod_no_inception4": "하아... 토르가 당신을 곧 처리할 겁니다.",
+   "vapok_mod_no_inception5": "토르가 당신의 힘을 빼앗아갑니다!!",
 
-   "vapok_mod_thor_saves_contents": "그 배낭에는 물건이 들어 있었다. 토르가 당신을 위해 저장했습니다.",
+   "vapok_mod_thor_saves_contents": "배낭에는 물건이 들어있었다. 토르는 당신을 위해 보관했습니다.",
 
-   "vapok_mod_useful_backpack": "당신의 배낭은 유용하다고 생각합니다.",
+   "vapok_mod_useful_backpack": "상당히 유용한 배낭이라고 생각합니다.",
    "vapok_mod_you_droped_bag": "배낭을 떨어뜨렸습니다!",
    "vapok_mod_level": "레벨",
    "vapok_mod_effect": "효과"

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.2",
+  "version_number": "1.6.3",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.3.0 - Key/Door Detection - Performance Tuning
* Keys stored in **Equipped Backpack** are detected for purposes of entering through doors. (e.g. Swamp Key opens Crypts).
  * Keys stored in backpacks NOT equipped, will be hidden from detection.
* Improved Backpack Protection Guards and Mod Compatibility
  * Ensuring that mods are handling your backpacks appropriately to prevent item loss and/or item dupping.
* Includes updated translations for Czech and Korean, as well as adds support for Swedish translation
* Changed Default Size of Level 1 Explorer's Wisppack from 4x4 (16 Slot Inventory) to a 8x2 (16 Slot Inventory)
* Quick Dropping (Outward Mode) now drops behind the Player running.
* Enhanced and Expanded Readme File