### PR TITLE
Release for 1.6.4

### DIFF
--- a/AdventureBackpacks.sln
+++ b/AdventureBackpacks.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Translations", "Translation
 		Translations\AdventureBackpacks.Korean.json = Translations\AdventureBackpacks.Korean.json
 		Translations\AdventureBackpacks.Czech.json = Translations\AdventureBackpacks.Czech.json
 		Translations\AdventureBackpacks.Swedish.json = Translations\AdventureBackpacks.Swedish.json
+		Translations\AdventureBackpacks.Spanish.json = Translations\AdventureBackpacks.Spanish.json
 	EndProjectSection
 EndProject
 Global

--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -1,12 +1,4 @@
-﻿/* Adventure Backpacks by Vapok
- *
- * This largely a new port of the original Jotunn Backpacks.  Only.. without the Jotunn, and other things.
- *
- * Planned Roadmap:
- * v1.5.0 - Adventure Begins - Revamping backpacks to be upgradable and offer new perks as upgrades happen. and offer backpacks at each stage of maturity. - DONE
- * v2.0.0 - To be determined! Possibly Bag Variants
- * 
- */
+﻿/* Adventure Backpacks by Vapok */
 
 using System;
 using System.Reflection;
@@ -35,7 +27,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.3";
+        private const string _version = "1.6.4";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/Assets/Effects/BackpackEffects.cs
+++ b/AdventureBackpacks/Assets/Effects/BackpackEffects.cs
@@ -23,35 +23,27 @@ public static class EquipmentEffectCache
         [UsedImplicitly]
         [HarmonyPriority(Priority.First)]
         public static void Prefix(Humanoid __instance)
-        {
+        { 
           activeEffects = new HashSet<StatusEffect>();
           backpackEffects = new HashSet<StatusEffect>();
 
-            var deMister = ObjectDB.instance.GetStatusEffect("Demister");
-            var slowFall = ObjectDB.instance.GetStatusEffect("SlowFall");
+          var deMister = ObjectDB.instance.GetStatusEffect("Demister");
+          var slowFall = ObjectDB.instance.GetStatusEffect("SlowFall");
 
-            foreach (StatusEffect eqipmentStatusEffect in __instance.m_eqipmentStatusEffects)
-            {
-              
-              if (eqipmentStatusEffect.Equals(deMister) && Demister.ShouldHaveDemister(__instance))
-              {
-                if (!backpackEffects.Contains(eqipmentStatusEffect)) 
-                  backpackEffects.Add(eqipmentStatusEffect);
-              }
-              
-              
-              if (eqipmentStatusEffect.Equals(slowFall) && FeatherFall.ShouldHaveFeatherFall(__instance))
-              {
-                if (!backpackEffects.Contains(eqipmentStatusEffect)) 
-                  backpackEffects.Add(eqipmentStatusEffect);
-              }
-            }
+          void EnsureEffectsAdded(StatusEffect se, bool shouldHave)
+          {
+            if (shouldHave && !backpackEffects.Any( x => x.name.Equals(se.name)))
+              backpackEffects.Add(se);
+          }
+          
+          EnsureEffectsAdded(deMister,Demister.ShouldHaveDemister(__instance));
+          EnsureEffectsAdded(slowFall,FeatherFall.ShouldHaveFeatherFall(__instance));
 
-            foreach (var backpackEffect in backpackEffects)
-            {
-              if (!activeEffects.Contains(backpackEffect))
-                activeEffects.Add(backpackEffect);
-            }
+          foreach (var backpackEffect in backpackEffects)
+          {
+            if (!activeEffects.Any( x => x.name.Equals(backpackEffect.name)))
+              activeEffects.Add(backpackEffect);
+          }
         }
         
         [UsedImplicitly]
@@ -71,7 +63,7 @@ public static class EquipmentEffectCache
 
             foreach (var activeEffect in activeEffects)
             {
-              if (!__instance.m_eqipmentStatusEffects.Contains(activeEffect))
+              if (!__instance.m_eqipmentStatusEffects.Any( x => x.name.Equals(activeEffect.name)))
                 backpackEffects.Add(activeEffect);
             }
           

--- a/AdventureBackpacks/Assets/Effects/BackpackEffects.cs
+++ b/AdventureBackpacks/Assets/Effects/BackpackEffects.cs
@@ -19,6 +19,8 @@ public static class EquipmentEffectCache
     [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.UpdateEquipmentStatusEffects))]
     public static class UpdateStatusEffects
     {
+      private static StatusEffect effectDemister;
+      private static StatusEffect effectSlowfall;
 
         [UsedImplicitly]
         [HarmonyPriority(Priority.First)]
@@ -27,8 +29,8 @@ public static class EquipmentEffectCache
           activeEffects = new HashSet<StatusEffect>();
           backpackEffects = new HashSet<StatusEffect>();
 
-          var deMister = ObjectDB.instance.GetStatusEffect("Demister");
-          var slowFall = ObjectDB.instance.GetStatusEffect("SlowFall");
+          effectDemister = effectDemister == null ? ObjectDB.instance.GetStatusEffect("Demister") : effectDemister;
+          effectSlowfall = effectSlowfall == null ? ObjectDB.instance.GetStatusEffect("SlowFall") : effectSlowfall;
 
           void EnsureEffectsAdded(StatusEffect se, bool shouldHave)
           {
@@ -36,8 +38,8 @@ public static class EquipmentEffectCache
               backpackEffects.Add(se);
           }
           
-          EnsureEffectsAdded(deMister,Demister.ShouldHaveDemister(__instance));
-          EnsureEffectsAdded(slowFall,FeatherFall.ShouldHaveFeatherFall(__instance));
+          EnsureEffectsAdded(effectDemister,Demister.ShouldHaveDemister(__instance));
+          EnsureEffectsAdded(effectSlowfall,FeatherFall.ShouldHaveFeatherFall(__instance));
 
           foreach (var backpackEffect in backpackEffects)
           {
@@ -101,5 +103,3 @@ public static class EquipmentEffectCache
       }
     }
 }
-
-

--- a/AdventureBackpacks/Assets/Items/BackpackItem.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItem.cs
@@ -2,6 +2,7 @@
 using System.Timers;
 using AdventureBackpacks.Assets.Factories;
 using BepInEx.Configuration;
+using ItemManager;
 using UnityEngine;
 using Vapok.Common.Abstractions;
 using Vapok.Common.Managers.Configuration;
@@ -18,7 +19,10 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
     private static ConfigSyncBase _config;
     private static ILogIt _logger;
     private string _configSection;
+    private string _englishSection;
     private string _localizedCategory;
+    private Localization _english;
+    private Localization english => _english ??= LocalizationCache.ForLanguage("English");
 
     public System.Timers.Timer InceptionTimer;
     public System.Timers.Timer YardSaleTimer;
@@ -45,8 +49,6 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
     internal ConfigEntry<float> SpeedMod { get; private set;}
     internal ConfigEntry<bool> EnableFreezing { get; private set;}
     internal ConfigEntry<BackpackBiomes> BackpackBiome { get; private set;}
-
-   
     
     internal ConfigSyncBase Config => _config;
     internal ILogIt Log => _logger;
@@ -55,6 +57,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
     protected BackpackItem(string prefabName, string itemName, string configSection = "") : base(prefabName,itemName)
     {
         _configSection = string.IsNullOrEmpty(configSection) ? $"Backpack: {itemName}" : configSection;
+        _englishSection = english.Localize(_configSection);
         _localizedCategory = Localization.instance.Localize(_configSection);
         Item.SectionName = _configSection;
         BackpackSize = new();
@@ -97,7 +100,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
     
     internal virtual void RegisterBackpackSize(int quality = 1, int x = 6, int y = 3)
     {
-        BackpackSize.Add(quality, ConfigSyncBase.SyncedConfig(_configSection, $"Backpack Size - Level {quality}", new Vector2(x, y),
+        BackpackSize.Add(quality, ConfigSyncBase.SyncedConfig(_englishSection, $"Backpack Size - Level {quality}", new Vector2(x, y),
             new ConfigDescription("Backpack size (width, height).\nMax width is 8 unless you want to break things.",
                 null,
                 new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 1 })));
@@ -107,7 +110,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
 
     internal virtual void RegisterWeightMultiplier(float defaultValue = 0.5f)
     {
-        WeightMultiplier = ConfigSyncBase.SyncedConfig(_configSection, "Weight Multiplier", defaultValue,
+        WeightMultiplier = ConfigSyncBase.SyncedConfig(_englishSection, "Weight Multiplier", defaultValue,
             new ConfigDescription("The weight of items stored in the backpack gets multiplied by this value.",
                 new AcceptableValueRange<float>(0f, 1f), // range between 0f and 1f will make it display as a percentage slider
                 new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 2 }));
@@ -117,7 +120,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
 
     internal virtual void RegisterBackpackBiome(BackpackBiomes defaultValue = BackpackBiomes.None)
     {
-        BackpackBiome = ConfigSyncBase.SyncedConfig(_configSection, "Backpack Biome", defaultValue,
+        BackpackBiome = ConfigSyncBase.SyncedConfig(_englishSection, "Backpack Biome", defaultValue,
             new ConfigDescription("The Biome this bag will draw it's effects from.",
                 null, 
                 new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 6 }));
@@ -125,7 +128,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
 
     internal virtual void RegisterCarryBonus(int defaultValue = 0)
     {
-        CarryBonus = ConfigSyncBase.SyncedConfig(_configSection, "Carry Bonus", defaultValue,
+        CarryBonus = ConfigSyncBase.SyncedConfig(_englishSection, "Carry Bonus", defaultValue,
             new ConfigDescription("Increases your carry capacity by this much (multiplied by item level) while wearing the backpack.",
                 new AcceptableValueRange<int>(0, 300),
                 new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 3 }));
@@ -135,7 +138,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
 
     internal virtual void RegisterSpeedMod(float defaultValue = -0.15f)
     {
-        SpeedMod = ConfigSyncBase.SyncedConfig(_configSection, "Speed Modifier", defaultValue,
+        SpeedMod = ConfigSyncBase.SyncedConfig(_englishSection, "Speed Modifier", defaultValue,
             new ConfigDescription("Wearing the backpack slows you down by this much.",
                 new AcceptableValueRange<float>(-1f, -0f),
                 new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 4 }));
@@ -145,7 +148,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
 
     internal virtual void RegisterEnableFreezing(bool defaultValue = true)
     {
-        EnableFreezing = ConfigSyncBase.SyncedConfig(_configSection, "Prevent freezing/cold?", defaultValue,
+        EnableFreezing = ConfigSyncBase.SyncedConfig(_englishSection, "Prevent freezing/cold?", defaultValue,
             new ConfigDescription("Wearing the backpack protects you against freezing/cold, just like capes.",
                 null,
                 new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 5 }));
@@ -153,4 +156,3 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         EnableFreezing!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }
 }
-

--- a/AdventureBackpacks/Extensions/PlayerExtensions.cs
+++ b/AdventureBackpacks/Extensions/PlayerExtensions.cs
@@ -9,7 +9,13 @@ public static class PlayerExtensions
 {
     public static bool IsBackpackEquipped(this Player player)
     {
-        return InventoryGuiPatches.BackpackEquipped;
+        if (player == null || player.GetInventory() == null)
+            return false;
+            
+        if (player.m_shoulderItem == null)
+            return false;
+
+        return player.m_shoulderItem.IsBackpack();
     }
 
     public static BackpackComponent GetEquippedBackpack(this Player player)
@@ -17,21 +23,13 @@ public static class PlayerExtensions
         if (player == null || player.GetInventory() == null)
             return null;
             
-        // Get a list of all equipped items.
-        var equippedItems = player.GetInventory().GetEquipedtems();
+        if (player.m_shoulderItem == null)
+            return null;
 
-        if (equippedItems is null) return null;
-
-        // Go through all the equipped items, match them for any of the names in backpackTypes.
-        // If a match is found, return the backpack ItemData object.
-        foreach (ItemDrop.ItemData item in equippedItems)
+        if (player.m_shoulderItem.IsBackpack())
         {
-            if (item.TryGetBackpackItem(out var backpack))
-            {
-                return item.Data().GetOrCreate<BackpackComponent>();
-            }
+            return player.m_shoulderItem.Data().GetOrCreate<BackpackComponent>();
         }
-
         // Return null if no backpacks are found.
         return null;
     }

--- a/AdventureBackpacks/Features/QuickTransfer.cs
+++ b/AdventureBackpacks/Features/QuickTransfer.cs
@@ -86,6 +86,14 @@ public static class QuickTransfer
 
         static void Finalizer(Exception __exception)
         {
+            if (__exception != null)
+            {
+                AdventureBackpacks.Log.Error($"Error: {__exception.Message}");
+                AdventureBackpacks.Log.Error($"Stack Trace: {__exception.StackTrace}");
+                AdventureBackpacks.Log.Error($"Source: {__exception.Source}");
+                throw __exception;
+            }
+
             _processingRightClick = false;
             _toInventory = null;
             _fromInventory = null;

--- a/AdventureBackpacks/Patches/Inventory.cs
+++ b/AdventureBackpacks/Patches/Inventory.cs
@@ -367,19 +367,30 @@ public static class InventoryPatches
                 if (__instance == null || Player.m_localPlayer == null)
                     return;
 
+                // Get a list of all items on the player.
+                List<ItemDrop.ItemData> items = __instance.GetAllItems();
+                
                 // If the inventory being checked for teleportability is the Player's inventory, see whether it contains any backpacks, and then check the backpack inventories for teleportability too
                 if (__instance == Player.m_localPlayer.GetInventory())
                 {
-                    // Get a list of all items on the player.
-                    List<ItemDrop.ItemData> items = __instance.GetAllItems();
-
+                    //am I wearing a backpack?
+                    if (Player.m_localPlayer.IsBackpackEquipped())
+                    {
+                        var backpack = Player.m_localPlayer.GetEquippedBackpack();
+                        if (backpack != null && !backpack.GetInventory().IsTeleportable())
+                        {
+                            __result = false;
+                            return;
+                        }
+                    }
+                    
                     // Go through all the items, match them for any of the names in backpackTypes.
                     // For each match found, check if the Inventory of that backpack is teleportable.
                     foreach (ItemDrop.ItemData item in items)
                     {
                         if (item == null)
                             continue;
-                        
+                    
                         if (item.IsBackpack())
                         {
                             if (!item.Data().GetOrCreate<BackpackComponent>().GetInventory().IsTeleportable())

--- a/AdventureBackpacks/Patches/Inventory.cs
+++ b/AdventureBackpacks/Patches/Inventory.cs
@@ -72,6 +72,14 @@ public static class InventoryPatches
         
         static void Finalizer(Exception __exception)
         {
+            if (__exception != null)
+            {
+                AdventureBackpacks.Log.Error($"Error: {__exception.Message}");
+                AdventureBackpacks.Log.Error($"Stack Trace: {__exception.StackTrace}");
+                AdventureBackpacks.Log.Error($"Source: {__exception.Source}");
+                throw __exception;
+            }
+
             _droppingOutside = false;
         }
     }
@@ -87,6 +95,14 @@ public static class InventoryPatches
         
         static void Finalizer(Exception __exception)
         {
+            if (__exception != null)
+            {
+                AdventureBackpacks.Log.Error($"Error: {__exception.Message}");
+                AdventureBackpacks.Log.Error($"Stack Trace: {__exception.StackTrace}");
+                AdventureBackpacks.Log.Error($"Source: {__exception.Source}");
+                throw __exception;
+            }
+
             _droppingOutside = false;
         }
     }
@@ -171,17 +187,20 @@ public static class InventoryPatches
 
             if (item.IsBackpack())
             {
-                var noInception = Backpacks.CheckForInception(__instance, item);
-                if (noInception)
+                if (__instance.HaveEmptySlot())
                 {
-                    if (!_movingItemBetweenContainers)
+                    var noInception = Backpacks.CheckForInception(__instance, item);
+                    if (noInception)
                     {
-                        ItemsAddedQueue.Enqueue(new KeyValuePair<ItemDrop.ItemData, DateTime>(item,DateTime.Now));
+                        if (!_movingItemBetweenContainers)
+                        {
+                            ItemsAddedQueue.Enqueue(new KeyValuePair<ItemDrop.ItemData, DateTime>(item,DateTime.Now));
+                        }
                     }
-                }
-                __result = noInception;
+                    __result = noInception;
             
-                return noInception;
+                    return noInception;
+                }
             }
             
             return true;
@@ -239,6 +258,14 @@ public static class InventoryPatches
         
         static void Finalizer(Exception __exception)
         {
+            if (__exception != null)
+            {
+                AdventureBackpacks.Log.Error($"Error: {__exception.Message}");
+                AdventureBackpacks.Log.Error($"Stack Trace: {__exception.StackTrace}");
+                AdventureBackpacks.Log.Error($"Source: {__exception.Source}");
+                throw __exception;
+            }
+
             _movingItemBetweenContainers = false;
         }
     }
@@ -265,6 +292,14 @@ public static class InventoryPatches
 
         static void Finalizer(Exception __exception)
         {
+            if (__exception != null)
+            {
+                AdventureBackpacks.Log.Error($"Error: {__exception.Message}");
+                AdventureBackpacks.Log.Error($"Stack Trace: {__exception.StackTrace}");
+                AdventureBackpacks.Log.Error($"Source: {__exception.Source}");
+                throw __exception;
+            }
+
             _movingItemBetweenContainers = false;
         }
     }
@@ -292,6 +327,14 @@ public static class InventoryPatches
 
         static void Finalizer(Exception __exception)
         {
+            if (__exception != null)
+            {
+                AdventureBackpacks.Log.Error($"Error: {__exception.Message}");
+                AdventureBackpacks.Log.Error($"Stack Trace: {__exception.StackTrace}");
+                AdventureBackpacks.Log.Error($"Source: {__exception.Source}");
+                throw __exception;
+            }
+
             _movingItemBetweenContainers = false;
         }
     }

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.3.0")]
-[assembly: AssemblyFileVersion("1.6.3.0")]
+[assembly: AssemblyVersion("1.6.4.0")]
+[assembly: AssemblyFileVersion("1.6.4.0")]

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,5 +1,15 @@
 # Adventure Backpacks Patchnotes
 
+# 1.6.4.0 - Bug Fixes + Spanish Language Translation
+* Adds Spanish Language Translation File
+  * Thanks to Esdac (on Discord) and lopezp9492 (GitHub) for contributions.
+* Fixes Take All Deletion of Backpacks when Targeted Container is Full
+* Fixes Gravestone Take All Duplications (same issue as above, but with Thor watching)
+* JewelCrafting removes status effects without regard for other mods that might be using it. Defensively guarded RemoveStatusEffects to ensure no unnecessary removal.
+* Configuration File is generated with split section names accidently.  Now section names in the config file itself should all be in English, and Configuration Manager should show localized Section Names.
+  * May or may not have an overall effect on random drops occuring.
+  * I have tested Config setting Drops Enabled/Disabled extensively and it is absolutely disabling drops if not enabled.
+
 # 1.6.3.0 - Key/Door Detection - Performance Tuning
 * Keys stored in **Equipped Backpack** are detected for purposes of entering through doors. (e.g. Swamp Key opens Crypts).
   * Keys stored in backpacks NOT equipped, will be hidden from detection.

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,12 +1,13 @@
 # Adventure Backpacks Patchnotes
 
-# 1.6.4.0 - Bug Fixes + Spanish Language Translation
+# 1.6.4.0 - Bug Fixes + Jewelcrafting Compatibility + Spanish Language Translation
 * Adds Spanish Language Translation File
   * Thanks to Esdac (on Discord) and lopezp9492 (GitHub) for contributions.
 * Fixes Take All Deletion of Backpacks when Targeted Container is Full
 * Fixes Gravestone Take All Duplications (same issue as above, but with Thor watching)
-* JewelCrafting removes status effects without regard for other mods that might be using it. Defensively guarded RemoveStatusEffects to ensure no unnecessary removal.
-* Configuration File is generated with split section names accidently.  Now section names in the config file itself should all be in English, and Configuration Manager should show localized Section Names.
+* Jewelcrafting consistently removes Status Effects repeatedly (whether it needs to or not), causing Backpack Wisplight to not function. 
+  * I have added in support to both prevent the removal, and optimize status effect identification. 
+* Configuration File is generated with split section names accidentally.  Now section names in the config file itself should all be in English, and Configuration Manager should show localized Section Names.
   * May or may not have an overall effect on random drops occuring.
   * I have tested Config setting Drops Enabled/Disabled extensively and it is absolutely disabling drops if not enabled.
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
 * Norwegian / norsk
 * Russian / Русский
 * Swedish / svenska
+* Spanish / Español
 * *Don't see your language, I'm looking for submissions for additional languages. Please find me on Discord (see link below) or submit a Pull Request!*
 
 ## Current Patch Notes
@@ -114,6 +115,8 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
 * Multi-User-Chests
 * Fast Item Transfer
 * Equipment and Quick Slots
+* Jewelcrafting
+* Shield Me Bruh!
 * _There's probably a ton of others. This mod is friendly to most mods. If you see a conflict though, let me know!_
 
 ## Incompatible Mods

--- a/Translations/AdventureBackpacks.Spanish.json
+++ b/Translations/AdventureBackpacks.Spanish.json
@@ -1,0 +1,38 @@
+{
+  "vapok_mod_item_backpack_meadows": "Mochila Pequeña",
+  "vapok_mod_item_backpack_meadows_description": "Una pequeña mochila capaz de contener cosas.",
+
+  "vapok_mod_item_backpack_blackforest": "Mochila Robusta",
+  "vapok_mod_item_backpack_blackforest_description": "Una mochila robusta, completa con hebillas y correas de cuero fino.",
+
+  "vapok_mod_item_backpack_swamp": "Bolsa de Sangre",
+  "vapok_mod_item_backpack_swamp_description": "Una mochila duradera sellada con bolsas de sangre impermeables.",
+
+  "vapok_mod_item_backpack_mountains": "Mochila de Sherpa",
+  "vapok_mod_item_backpack_mountains_description": "Una mochila ártica, apta para largas caminatas por las montañas.",
+
+  "vapok_mod_item_backpack_plains": "Mochila de piel de Lox",
+  "vapok_mod_item_backpack_plains_description": "Una mochila para aventuras hecha de piel de Lox, es extremadamente resistente.",
+
+  "vapok_mod_item_backpack_mistlands": "Mochila Magica de Explorador",
+  "vapok_mod_item_backpack_mistlands_description": "Una mochila mística finamente elaborada. Completa con su propia caja de almacenamiento. Nadie está muy seguro de cómo funciona.",
+
+  "vapok_mod_item_rugged_backpack": "Mochila Antigua",
+  "vapok_mod_item_rugged_backpack_description": "Una mochila robusta, completa con hebillas y correas de cuero fino.",
+
+  "vapok_mod_item_arctic_backpack": "Mochila Ártica Antigua",
+  "vapok_mod_item_arctic_backpack_description": "Para excursiónes por las montanas",
+
+  "vapok_mod_no_inception1": "No enojes a los Dioses.",
+  "vapok_mod_no_inception2": "Se te a advertido.",
+  "vapok_mod_no_inception3": "¡Has enojado a los Dioses!",
+  "vapok_mod_no_inception4": "Suspiro... Thor se ocupará de ti pronto.",
+  "vapok_mod_no_inception5": "¡¡Thor te ha despojado de tus poderes!!",
+
+  "vapok_mod_thor_saves_contents": "Esa mochila tenía cosas adentro. Thor las guado por ti.",
+  
+  "vapok_mod_useful_backpack": "Tu mochila se siente útil.",
+  "vapok_mod_you_droped_bag": "Tiraste la mochila!",
+  "vapok_mod_level": "Nivel",
+  "vapok_mod_effect": "Efecto"
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.3",
+  "version_number": "1.6.4",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.4.0 - Bug Fixes + Jewelcrafting Compatibility + Spanish Language Translation
* Adds Spanish Language Translation File
  * Thanks to Esdac (on Discord) and lopezp9492 (GitHub) for contributions.
* Fixes Take All Deletion of Backpacks when Targeted Container is Full
* Fixes Gravestone Take All Duplications (same issue as above, but with Thor watching)
* Jewelcrafting consistently removes Status Effects repeatedly (whether it needs to or not), causing Backpack Wisplight to not function. 
  * I have added in support to both prevent the removal, and optimize status effect identification. 
* Configuration File is generated with split section names accidentally.  Now section names in the config file itself should all be in English, and Configuration Manager should show localized Section Names.
  * May or may not have an overall effect on random drops occuring.
  * I have tested Config setting Drops Enabled/Disabled extensively and it is absolutely disabling drops if not enabled.