### PR TITLE
Release 1.6.12

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -12,6 +12,7 @@ using BepInEx;
 using HarmonyLib;
 using ItemManager;
 using JetBrains.Annotations;
+using UnityEngine;
 using Vapok.Common.Abstractions;
 using Vapok.Common.Managers;
 using Vapok.Common.Managers.Configuration;
@@ -28,7 +29,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.11";
+        private const string _version = "1.6.12";
         
         //Interface Properties
         public string PluginId => _pluginId;
@@ -98,13 +99,15 @@ namespace AdventureBackpacks
                     Backpacks.PerformYardSale(Player.m_localPlayer, backpack.Item);
             }
             
-            if (!KeyPressTool.IgnoreKeyPresses(true) && KeyPressTool.CheckKeyDown(ConfigRegistry.HotKeyOpen.Value) && Player.m_localPlayer.CanOpenBackpack())
+            if (!KeyPressTool.IgnoreKeyPresses(true) && (ConfigRegistry.HotKeyOpen.Value.IsDown() || ZInput.GetButtonDown(ConfigRegistry.HotKeyOpen.Value.Serialize()) ) && Player.m_localPlayer.CanOpenBackpack())
             {
+                ZInput.ResetButtonStatus(ConfigRegistry.HotKeyOpen.Value.Serialize());
                 Player.m_localPlayer.OpenBackpack();
             }
 
-            if (ConfigRegistry.OutwardMode.Value && !KeyPressTool.IgnoreKeyPresses(true) && KeyPressTool.CheckKeyDown(ConfigRegistry.HotKeyDrop.Value) && Player.m_localPlayer.CanOpenBackpack())
+            if (ConfigRegistry.OutwardMode.Value && !KeyPressTool.IgnoreKeyPresses(true) && (ConfigRegistry.HotKeyDrop.Value.IsDown() || ZInput.GetButtonDown(ConfigRegistry.HotKeyDrop.Value.Serialize())) && Player.m_localPlayer.CanOpenBackpack())
             {
+                ZInput.ResetButtonStatus(ConfigRegistry.HotKeyOpen.Value.Serialize());
                 Player.m_localPlayer.QuickDropBackpack();
             }
 

--- a/AdventureBackpacks/Configuration/ConfigRegistry.cs
+++ b/AdventureBackpacks/Configuration/ConfigRegistry.cs
@@ -10,8 +10,9 @@ namespace AdventureBackpacks.Configuration
     public class ConfigRegistry : ConfigSyncBase
     {
         //Configuration Entry Privates
-        internal static ConfigEntry<KeyCode> HotKeyOpen { get; private set; }
-        internal static ConfigEntry<KeyCode> HotKeyDrop { get; private set;}
+        internal static ConfigEntry<KeyboardShortcut> HotKeyOpen { get; private set; }
+        internal static ConfigEntry<KeyboardShortcut> HotKeyDrop { get; private set;}
+        internal static ConfigEntry<bool> OpenWithInventory { get; private set;}
         internal static ConfigEntry<bool> CloseInventory { get; private set;}
         internal static ConfigEntry<bool> OutwardMode { get; private set;}
         
@@ -31,18 +32,23 @@ namespace AdventureBackpacks.Configuration
                 return;
             
             //User Configs
-            HotKeyOpen = _config.Bind("Local Config", "Open Backpack", KeyCode.I,
+            HotKeyOpen = _config.Bind("Local Config", "Open Backpack", new KeyboardShortcut(KeyCode.I),
                 new ConfigDescription("Hotkey to open backpack.", null, new ConfigurationManagerAttributes{ Order = 3 }));
             
             HotKeyDrop = _config.Bind(
-                "Local Config", "Quickdrop Backpack", KeyCode.Y,
+                "Local Config", "Quickdrop Backpack", new KeyboardShortcut(KeyCode.Y),
                 new ConfigDescription("Hotkey to quickly drop backpack while on the run.",
                     null,
                     new ConfigurationManagerAttributes { Order = 2 }));
             
+            OpenWithInventory = _config.Bind(
+                "Local Config", "Open with Inventory", false,
+                new ConfigDescription("If enabled, both backpack and inventory will open when Inventory is opened.",
+                    null, new ConfigurationManagerAttributes { Order = 2 }));
+            
             CloseInventory = _config.Bind(
                 "Local Config", "Close Inventory", true,
-                new ConfigDescription("If set to true, both backpack and inventory will close with Open Backpack keybind is pressed while Inventory is open.",
+                new ConfigDescription("If enabled, both backpack and inventory will close with Open Backpack keybind is pressed while Inventory is open.",
                     null, new ConfigurationManagerAttributes { Order = 1 }));
             
             OutwardMode = _config.Bind(

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.11.0")]
-[assembly: AssemblyFileVersion("1.6.11.0")]
+[assembly: AssemblyVersion("1.6.12.0")]
+[assembly: AssemblyFileVersion("1.6.12.0")]

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -3,8 +3,8 @@
 # 1.6.12.0 - Redefining Keymappings and Open with Inventory Option
 * Adjusted Config Keymappings to allow for Gamepad, Mouse, or Keyboard to be set.
   * Untested Controller Support - I'm hoping this works, but it might not. Please provide feedback.
-* Added in additional configuration option to Open Backpack Inventory when Player Inventory is Opened.
-  * This defaults to Disabled. Set to Enabled (true) to open backpack at same time as inventory.
+* Added an additional configuration option to Open Backpack Inventory when Player Inventory is Opened.
+  * This defaults to Disabled. Set to Enabled (true) to open the backpack at the same time as inventory.
 
 # 1.6.11.0 - Clean Up and Upgrade of BepInEx
 * Updates to BepInEx 5.4.21

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,5 +1,11 @@
 # Adventure Backpacks Patchnotes
 
+# 1.6.12.0 - Redefining Keymappings and Open with Inventory Option
+* Adjusted Config Keymappings to allow for Gamepad, Mouse, or Keyboard to be set.
+  * Untested Controller Support - I'm hoping this works, but it might not. Please provide feedback.
+* Added in additional configuration option to Open Backpack Inventory when Player Inventory is Opened.
+  * This defaults to Disabled. Set to Enabled (true) to open backpack at same time as inventory.
+
 # 1.6.11.0 - Clean Up and Upgrade of BepInEx
 * Updates to BepInEx 5.4.21
 * Various Clean Up

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
   * Configure Speed Modification
     * Configure Speed Modification (slowness).
       * Upon each quality upgrade of backpack, speed modification is reduced (never eliminated).
+  * Configure Opening of Backpack with Inventory
+    * When enabled, opens backpack inventory with player inventory without additional interaction
+    * Can also set Mouse, Keyboard, and Gamepad bindings.
 * Backpack Inventory Protection Guard
   * Every backpack inventory is specially handled by Thor himself and is monitored for any interactions that might otherwise harm the existence of items in your backpacks.
   * Backpacks in Backpacks is not allowed and the only feature that is not configurable. This is how the Allfather dreamt of it.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.11",
+  "version_number": "1.6.12",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.12.0 - Redefining Keymappings and Open with Inventory Option
* Adjusted Config Keymappings to allow for Gamepad, Mouse, or Keyboard to be set.
  * Untested Controller Support - I'm hoping this works, but it might not. Please provide feedback.
* Added an additional configuration option to Open Backpack Inventory when Player Inventory is Opened.
  * This defaults to Disabled. Set to Enabled (true) to open the backpack at the same time as inventory.