### PR TITLE
Release 1.6.14

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -60,11 +60,8 @@ namespace AdventureBackpacks
             
             //Waiting For Startup
             Waiter = new Waiting();
-
-            var initOptions = new Initializer.InitOptions(false, true, true, true, false, false, true, true);
-            
             //Initialize Managers
-            Initializer.LoadManagers(initOptions);
+            Initializer.LoadManagers(false, true, true, true, false, false, true, true);
 
             //Register Configuration Settings
             _config = new ConfigRegistry(_instance);

--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -60,9 +60,11 @@ namespace AdventureBackpacks
             
             //Waiting For Startup
             Waiter = new Waiting();
+
+            var initOptions = new Initializer.InitOptions(false, true, true, true, false, false, true, true);
             
             //Initialize Managers
-            Initializer.LoadManagers();
+            Initializer.LoadManagers(initOptions);
 
             //Register Configuration Settings
             _config = new ConfigRegistry(_instance);

--- a/AdventureBackpacks/AdventureBackpacks.csproj
+++ b/AdventureBackpacks/AdventureBackpacks.csproj
@@ -75,6 +75,9 @@
         <Reference Include="UnityEngine.PhysicsModule">
           <HintPath>..\..\References\BepInEx\5.4.2101\unstripped_corlib\UnityEngine.PhysicsModule.dll</HintPath>
         </Reference>
+        <Reference Include="UnityEngine.UI">
+          <HintPath>..\..\References\BepInEx\5.4.2101\unstripped_corlib\UnityEngine.UI.dll</HintPath>
+        </Reference>
         <Reference Include="Vapok.Common">
           <HintPath>..\..\References\Vapok.Common\Vapok.Common.dll</HintPath>
         </Reference>

--- a/AdventureBackpacks/Configuration/ConfigRegistry.cs
+++ b/AdventureBackpacks/Configuration/ConfigRegistry.cs
@@ -13,6 +13,7 @@ namespace AdventureBackpacks.Configuration
         internal static ConfigEntry<KeyboardShortcut> HotKeyOpen { get; private set; }
         internal static ConfigEntry<KeyboardShortcut> HotKeyDrop { get; private set;}
         internal static ConfigEntry<bool> OpenWithInventory { get; private set;}
+        internal static ConfigEntry<bool> OpenWithHoverInteract { get; private set;}
         internal static ConfigEntry<bool> CloseInventory { get; private set;}
         internal static ConfigEntry<bool> OutwardMode { get; private set;}
         
@@ -39,17 +40,22 @@ namespace AdventureBackpacks.Configuration
                 "Local Config", "Quickdrop Backpack", new KeyboardShortcut(KeyCode.Y),
                 new ConfigDescription("Hotkey to quickly drop backpack while on the run.",
                     null,
-                    new ConfigurationManagerAttributes { Order = 2 }));
+                    new ConfigurationManagerAttributes { Order = 1 }));
             
             OpenWithInventory = _config.Bind(
                 "Local Config", "Open with Inventory", false,
                 new ConfigDescription("If enabled, both backpack and inventory will open when Inventory is opened.",
-                    null, new ConfigurationManagerAttributes { Order = 2 }));
+                    null, new ConfigurationManagerAttributes { Order = 3 }));
+            
+            OpenWithHoverInteract = _config.Bind(
+                "Local Config", "Open with Interactive Hover", false,
+                new ConfigDescription("If enabled, backpack will only open while hovering over equipped backpack and pressing hotkey.  This option overrides Open with Inventory.",
+                    null, new ConfigurationManagerAttributes { Order = 3 }));
             
             CloseInventory = _config.Bind(
                 "Local Config", "Close Inventory", true,
                 new ConfigDescription("If enabled, both backpack and inventory will close with Open Backpack keybind is pressed while Inventory is open.",
-                    null, new ConfigurationManagerAttributes { Order = 1 }));
+                    null, new ConfigurationManagerAttributes { Order = 2 }));
             
             OutwardMode = _config.Bind(
                 "Local Config", "Outward Mode", false,

--- a/AdventureBackpacks/Features/QuickTransfer.cs
+++ b/AdventureBackpacks/Features/QuickTransfer.cs
@@ -41,7 +41,7 @@ public static class QuickTransfer
         {
             if (!FeatureInitialized)
                 return;
-            
+
             if (Player.m_localPlayer == null || __instance == null || item == null)
                 return;
 
@@ -50,12 +50,52 @@ public static class QuickTransfer
 
             if (Chainloader.PluginInfos.ContainsKey("blumaye.quicktransfer"))
             {
-                AdventureBackpacks.Log.Warning("blumaye.quicktransfer mod is enabled. Adventure Backpack's Quick Transfer disabled.");
+                AdventureBackpacks.Log.Warning(
+                    "blumaye.quicktransfer mod is enabled. Adventure Backpack's Quick Transfer disabled.");
                 return;
             }
 
+            //If item is equipped, let's skip the move, because this is most likely an unequip action.
             if (item.m_equiped)
                 return;
+
+            //If I have a backpack open, and I currently have nothing in the equipped slot, I want to prioritize equipping it over storing it.
+            if (item.IsEquipable() && grid.m_inventory == Player.m_localPlayer.GetInventory())
+            {
+                switch (item.m_shared.m_itemType)
+                {
+                    case ItemDrop.ItemData.ItemType.Helmet:
+                        if (Player.m_localPlayer.m_helmetItem == null)
+                            return;
+                        break;
+                    case ItemDrop.ItemData.ItemType.Chest:
+                        if (Player.m_localPlayer.m_chestItem == null)
+                            return;
+                        break;
+                    case ItemDrop.ItemData.ItemType.Legs:
+                        if (Player.m_localPlayer.m_legItem == null)
+                            return;
+                        break;
+                    case ItemDrop.ItemData.ItemType.Bow:
+                    case ItemDrop.ItemData.ItemType.TwoHandedWeapon:
+                    case ItemDrop.ItemData.ItemType.OneHandedWeapon:
+                        if (Player.m_localPlayer.m_rightItem == null)
+                            return;
+                        break;
+                    case ItemDrop.ItemData.ItemType.Shoulder:
+                        if (Player.m_localPlayer.m_shoulderItem == null)
+                            return;
+                        break;
+                    case ItemDrop.ItemData.ItemType.Utility:
+                        if (Player.m_localPlayer.m_utilityItem == null)
+                            return;
+                        break;
+                    case ItemDrop.ItemData.ItemType.Shield:
+                        if (Player.m_localPlayer.m_leftItem == null)
+                            return;
+                        break;
+                }
+            }
 
             var containerInventory = __instance.m_currentContainer.GetInventory();
             

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,12 +1,17 @@
 # Adventure Backpacks Patchnotes
 
-# 1.6.14.0 - Fixing Equippable Items
+# 1.6.14.0 - Fixing Equippable Items, Adding Hover Over Interaction option, Fixing Signs.
+* New Feature: Open Inventory with Hover Interaction
+  * When enabled, this will override the Open with Inventory and Close Inventory Options.
+  * When enabled, hovering over an equipped backpack item in player inventory and pressing the Backpack Open Hot Key will open equipped backpack.
 * Discovered a bug (or unintended interaction) that prevented the ability to equip armor if backpack is configured to open with inventory (and close with inventory) when using "Right Click Quick Transfer" functionality
   * This has been fixed. Right Click Quick Transfer will now detect if there is armor in the spot it would be equiped at.
     * If no item is equipped in it's intended slot, it will equip the item instead of transfering it.
     * if item slot is already filled, it will quick transfer the equippable item.
     * This does mean, if you intent to swap out armor, you'll have to unequip the current item equipped manually.
       * This is not an issue if Right Click Quick Transfer is disabled.
+* When typing in Signs, inventory was opening with hot key.
+  * Fixed to prevent inventory from opening while typing in signs.
 
 # 1.6.13.0 - Refactor of Backpack Interaction Controls
 * Enhanced and improved the mechanics behind how backpacks open.

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -1,5 +1,13 @@
 # Adventure Backpacks Patchnotes
 
+# 1.6.14.0 - Fixing Equippable Items
+* Discovered a bug (or unintended interaction) that prevented the ability to equip armor if backpack is configured to open with inventory (and close with inventory) when using "Right Click Quick Transfer" functionality
+  * This has been fixed. Right Click Quick Transfer will now detect if there is armor in the spot it would be equiped at.
+    * If no item is equipped in it's intended slot, it will equip the item instead of transfering it.
+    * if item slot is already filled, it will quick transfer the equippable item.
+    * This does mean, if you intent to swap out armor, you'll have to unequip the current item equipped manually.
+      * This is not an issue if Right Click Quick Transfer is disabled.
+
 # 1.6.13.0 - Refactor of Backpack Interaction Controls
 * Enhanced and improved the mechanics behind how backpacks open.
 * Fixed the backpack not closing when open.

--- a/PATCHNOTES.md
+++ b/PATCHNOTES.md
@@ -3,14 +3,14 @@
 # 1.6.14.0 - Fixing Equippable Items, Adding Hover Over Interaction option, Fixing Signs.
 * New Feature: Open Inventory with Hover Interaction
   * When enabled, this will override the Open with Inventory and Close Inventory Options.
-  * When enabled, hovering over an equipped backpack item in player inventory and pressing the Backpack Open Hot Key will open equipped backpack.
-* Discovered a bug (or unintended interaction) that prevented the ability to equip armor if backpack is configured to open with inventory (and close with inventory) when using "Right Click Quick Transfer" functionality
-  * This has been fixed. Right Click Quick Transfer will now detect if there is armor in the spot it would be equiped at.
-    * If no item is equipped in it's intended slot, it will equip the item instead of transfering it.
-    * if item slot is already filled, it will quick transfer the equippable item.
-    * This does mean, if you intent to swap out armor, you'll have to unequip the current item equipped manually.
+  * When enabled, hovering over an equipped backpack item in the player inventory and pressing the Backpack Open Hot Key will open equipped backpack.
+* Discovered a bug (or unintended interaction) that prevented the ability to equip armor if a backpack is configured to open with inventory (and close with inventory) when using "Right Click Quick Transfer" functionality
+  * This has been fixed. Right Click Quick Transfer will now detect if there is armor in the spot it would be equipped at.
+    * If no item is equipped in it's intended slot, it will equip the item instead of transferring it.
+    * if item slot is already filled, it will quick transfer the equipable item.
+    * This does mean, if your intent is to swap out armor, you'll have to unequip the current item equipped manually.
       * This is not an issue if Right Click Quick Transfer is disabled.
-* When typing in Signs, inventory was opening with hot key.
+* When typing in Signs, inventory was opening with a hotkey.
   * Fixed to prevent inventory from opening while typing in signs.
 
 # 1.6.13.0 - Refactor of Backpack Interaction Controls

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
   * Configure Opening of Backpack with Inventory
     * When enabled, opens backpack inventory with player inventory without additional interaction
     * Can also set Mouse, Keyboard, and Gamepad bindings.
+  * Configure Opening of Backpack with Hover + Interaction
+    * When enabled, will open backpack when hovered over in Player Inventory and the Open Hot Key is pressed.
+    * This feature overrides Open with Inventory and Close with Inventory.
+    * This feature will only work when backpack is in player inventory, and NOT in Extended Inventory windows.
 * Backpack Inventory Protection Guard
   * Every backpack inventory is specially handled by Thor himself and is monitored for any interactions that might otherwise harm the existence of items in your backpacks.
   * Backpacks in Backpacks is not allowed and the only feature that is not configurable. This is how the Allfather dreamt of it.


### PR DESCRIPTION
# 1.6.14.0 - Fixing Equippable Items, Adding Hover Over Interaction option, Fixing Signs.
* New Feature: Open Inventory with Hover Interaction
  * When enabled, this will override the Open with Inventory and Close Inventory Options.
  * When enabled, hovering over an equipped backpack item in the player inventory and pressing the Backpack Open Hot Key will open equipped backpack.
* Discovered a bug (or unintended interaction) that prevented the ability to equip armor if a backpack is configured to open with inventory (and close with inventory) when using "Right Click Quick Transfer" functionality
  * This has been fixed. Right Click Quick Transfer will now detect if there is armor in the spot it would be equipped at.
    * If no item is equipped in it's intended slot, it will equip the item instead of transferring it.
    * if item slot is already filled, it will quick transfer the equipable item.
    * This does mean, if your intent is to swap out armor, you'll have to unequip the current item equipped manually.
      * This is not an issue if Right Click Quick Transfer is disabled.
* When typing in Signs, inventory was opening with a hotkey.
  * Fixed to prevent inventory from opening while typing in signs.