### PR TITLE
MaxAxe Compatibility Hotfix

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -28,7 +28,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.16";
+        private const string _version = "1.6.17";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/Patches/Player.cs
+++ b/AdventureBackpacks/Patches/Player.cs
@@ -45,7 +45,7 @@ public class PlayerPatches
 
                 if (removedCounter < amount)
                 {
-                    player.m_inventory.RemoveItem(item);
+                    player.m_inventory.RemoveItem(item,1);
                     removedCounter++;
                 }
             }

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.16.0")]
-[assembly: AssemblyFileVersion("1.6.16.0")]
+[assembly: AssemblyVersion("1.6.17.0")]
+[assembly: AssemblyFileVersion("1.6.17.0")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.17 - MaxAxe Compatibility Hotfix
+* Changes to crafting were assuming unstackable items.
+  * Fixed to allow stackable items (that can be equipped) to be removed correctly.
+
 # 1.6.16 - Various Updates
 * Crafting bags will no longer allow you to consume equipped cape's.
   * To craft a bag with a cape, and the only one in inventory is equipped, it must be unequipped in order for it to be used.

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.16",
+  "version_number": "1.6.17",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [
-    "denikson-BepInExPack_Valheim-5.4.2101"
+    "denikson-BepInExPack_Valheim-5.4.2102"
   ]
 }


### PR DESCRIPTION
* Changes to crafting were assuming unstackable items.
  * Fixed to allow stackable items (that can be equipped) to be removed correctly.