### PR TITLE
Release 1.6.18

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -28,7 +28,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.17";
+        private const string _version = "1.6.18";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.17.0")]
-[assembly: AssemblyFileVersion("1.6.17.0")]
+[assembly: AssemblyVersion("1.6.18.0")]
+[assembly: AssemblyFileVersion("1.6.18.0")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.18 - Cheb's Necromancy Hotfix
+* Fixes Cheb's Necromancy Asset Issue
+* Put in strong error handling for when this will happen again in the future.
+
 # 1.6.17 - MaxAxe Compatibility Hotfix
 * Changes to crafting were assuming unstackable items.
   * Fixed to allow stackable items (that can be equipped) to be removed correctly.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.17",
+  "version_number": "1.6.18",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.18 - Cheb's Necromancy Hotfix
* Fixes Cheb's Necromancy Asset Issue
* Put in strong error handling for when this will happen again in the future.