### PR TITLE
Release 1.6.23

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -28,7 +28,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.22";
+        private const string _version = "1.6.23";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/Assets/Backpacks.cs
+++ b/AdventureBackpacks/Assets/Backpacks.cs
@@ -205,21 +205,25 @@ namespace AdventureBackpacks.Assets
         {
             if (itemData == null)
                 return null;
+
+            if (!itemData.TryGetBackpackItem(out var backpack))
+                return null;
+            
             var backpackName = itemData.m_shared.m_name;
             var backpackQuality = itemData.m_quality;
             var statusEffects = new CustomSE(Enums.StatusEffects.Stats, $"SE_{backpackName}_{backpackQuality}");
-            
-            statusEffects.Effect.m_name = $"{backpackName} $vapok_mod_level {backpackQuality} $vapok_mod_effect";
-            statusEffects.Effect.m_startMessageType = MessageHud.MessageType.TopLeft;
-            statusEffects.Effect.m_startMessage = $"$vapok_mod_useful_backpack";
-            
+            var defaultStatusName = $"{backpackName} $vapok_mod_level {backpackQuality} $vapok_mod_effect";
+
+            if (backpack.ShowBackpackStatusEffect.Value)
+            {
+                statusEffects.Effect.m_name = string.IsNullOrEmpty(backpack.CustomStatusEffectName.Value) ? defaultStatusName : backpack.CustomStatusEffectName.Value;
+                statusEffects.Effect.m_startMessageType = MessageHud.MessageType.TopLeft;
+                statusEffects.Effect.m_startMessage = $"$vapok_mod_useful_backpack";
+            }
 
             var modifierList = new List<HitData.DamageModPair>();
             //Set Armor Default
             itemData.m_shared.m_armor = itemData.m_shared.m_armorPerLevel * backpackQuality;
-            
-            if (!itemData.TryGetBackpackItem(out var backpack))
-                return null;
             
             //Apply Frost Resistance if configured.
             var frostResistEffect = EffectsFactory.EffectList[BackpackEffect.FrostResistance];
@@ -259,7 +263,10 @@ namespace AdventureBackpacks.Assets
             
             itemData.m_shared.m_maxDurability = 1000f;
             ((SE_Stats)statusEffects.Effect).m_mods = modifierList;
-            ((SE_Stats)statusEffects.Effect).m_icon = itemData.GetIcon();
+            if (backpack.ShowBackpackStatusEffect.Value)
+            {
+                ((SE_Stats)statusEffects.Effect).m_icon = itemData.GetIcon();   
+            }
 
             itemData.AddSEToItem(statusEffects);
             return statusEffects;

--- a/AdventureBackpacks/Assets/Items/BackpackItem.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItem.cs
@@ -48,6 +48,8 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
     internal ConfigEntry<int> CarryBonus { get; private set;}
     internal ConfigEntry<float> SpeedMod { get; private set;}
     internal ConfigEntry<bool> EnableFreezing { get; private set;}
+    internal ConfigEntry<bool> ShowBackpackStatusEffect { get; private set;}
+    internal ConfigEntry<string> CustomStatusEffectName { get; private set;}
     internal ConfigEntry<BackpackBiomes> BackpackBiome { get; private set;}
     
     internal ConfigSyncBase Config => _config;
@@ -107,7 +109,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         BackpackSize.Add(quality, ConfigSyncBase.SyncedConfig(_englishSection, $"Backpack Size - Level {quality}", new Vector2(x, y),
             new ConfigDescription("Backpack size (width, height).\nMax width is 8 unless you want to break things.",
                 null,
-                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 1 })));
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 3 })));
         
         BackpackSize[quality]!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }
@@ -117,7 +119,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         WeightMultiplier = ConfigSyncBase.SyncedConfig(_englishSection, "Weight Multiplier", defaultValue,
             new ConfigDescription("The weight of items stored in the backpack gets multiplied by this value.",
                 new AcceptableValueRange<float>(0f, 1f), // range between 0f and 1f will make it display as a percentage slider
-                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 2 }));
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 4 }));
         
         WeightMultiplier!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }
@@ -127,7 +129,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         BackpackBiome = ConfigSyncBase.SyncedConfig(_englishSection, "Backpack Biome", defaultValue,
             new ConfigDescription("The Biome this bag will draw it's effects from.",
                 null, 
-                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 6 }));
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 5 }));
         BackpackBiome.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }
 
@@ -136,9 +138,26 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         CarryBonus = ConfigSyncBase.SyncedConfig(_englishSection, "Carry Bonus", defaultValue,
             new ConfigDescription("Increases your carry capacity by this much (multiplied by item level) while wearing the backpack.",
                 new AcceptableValueRange<int>(0, 300),
-                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 3 }));
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 6 }));
         
         CarryBonus!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
+    }
+
+    internal virtual void RegisterStatusEffectInfo(bool defaultShowStatus = true, string defaultEffectName = "")
+    {
+        ShowBackpackStatusEffect = ConfigSyncBase.SyncedConfig(_englishSection, "Show Status Effect", defaultShowStatus,
+            new ConfigDescription("Toggles the visibility of the Backpack Status Effect",
+                null,
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 1 }));
+        
+        ShowBackpackStatusEffect!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
+
+        CustomStatusEffectName = ConfigSyncBase.SyncedConfig(_englishSection, "Custom Effect Name", defaultEffectName,
+            new ConfigDescription("Set your own effect name. Leave Empty to use Default Effect name",
+                null,
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 2 }));
+        
+        CustomStatusEffectName!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }
 
     internal virtual void RegisterSpeedMod(float defaultValue = -0.15f)
@@ -146,7 +165,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         SpeedMod = ConfigSyncBase.SyncedConfig(_englishSection, "Speed Modifier", defaultValue,
             new ConfigDescription("Wearing the backpack slows you down by this much.",
                 new AcceptableValueRange<float>(-1f, -0f),
-                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 4 }));
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 7 }));
         
         SpeedMod!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }
@@ -156,7 +175,7 @@ internal abstract class BackpackItem : AssetItem, IBackpackItem
         EnableFreezing = ConfigSyncBase.SyncedConfig(_englishSection, "Prevent freezing/cold?", defaultValue,
             new ConfigDescription("Wearing the backpack protects you against freezing/cold, just like capes.",
                 null,
-                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 5 }));
+                new ConfigurationManagerAttributes { Category = _localizedCategory, Order = 8 }));
         
         EnableFreezing!.SettingChanged += Backpacks.UpdateItemDataConfigValues;
     }

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackBlackForest.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackBlackForest.cs
@@ -36,6 +36,7 @@ internal class BackpackBlackForest : BackpackItem
         RegisterBackpackSize(2,4,2);
         RegisterBackpackSize(3,5,2);
         RegisterBackpackSize(4,6,2);
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(10);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMeadows.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMeadows.cs
@@ -34,6 +34,7 @@ internal class BackpackMeadows : BackpackItem
         RegisterBackpackSize(2,4,1);
         RegisterBackpackSize(3,5,1);
         RegisterBackpackSize(4,6,1);
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(5);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMistlands.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMistlands.cs
@@ -39,6 +39,7 @@ internal class BackpackMistlands : BackpackItem
         RegisterBackpackSize(2,5,4);
         RegisterBackpackSize(3,6,4);
         RegisterBackpackSize(4,7,4);
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(30);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMountains.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackMountains.cs
@@ -33,6 +33,7 @@ internal class BackpackMountains : BackpackItem
         RegisterBackpackSize(2,4,3);
         RegisterBackpackSize(3,5,3);
         RegisterBackpackSize(4,6,3);
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(20);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackPlains.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackPlains.cs
@@ -35,6 +35,7 @@ internal class BackpackPlains : BackpackItem
         RegisterBackpackSize(2,4,4);
         RegisterBackpackSize(3,5,4);
         RegisterBackpackSize(4,6,4);
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(25);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/BackpackSwamp.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/BackpackSwamp.cs
@@ -36,6 +36,7 @@ internal class BackpackSwamp : BackpackItem
         RegisterBackpackSize(2,3,3);
         RegisterBackpackSize(3,4,3);
         RegisterBackpackSize(4,5,3);
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(15);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/LegacyIronBackpack.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/LegacyIronBackpack.cs
@@ -15,6 +15,7 @@ internal class LegacyIronBackpack: BackpackItem
     {
         RegisterBackpackBiome();
         RegisterBackpackSize();
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(25);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Assets/Items/BackpackItems/LegacySilverBackpack.cs
+++ b/AdventureBackpacks/Assets/Items/BackpackItems/LegacySilverBackpack.cs
@@ -15,6 +15,7 @@ internal class LegacySilverBackpack : BackpackItem
     {
         RegisterBackpackBiome();
         RegisterBackpackSize();
+        RegisterStatusEffectInfo();
         RegisterWeightMultiplier();
         RegisterCarryBonus(45);
         RegisterSpeedMod();

--- a/AdventureBackpacks/Extensions/PlayerExtensions.cs
+++ b/AdventureBackpacks/Extensions/PlayerExtensions.cs
@@ -45,16 +45,6 @@ public static class PlayerExtensions
             return;
         
         var backpackContainer = player.gameObject.GetComponent<Container>();
-            
-        if (backpackContainer == null)
-            backpackContainer = player.gameObject.AddComponent<Container>();
-
-        var backpack = GetEquippedBackpack(player);
-        var inventory = backpack.GetInventory();
-        backpackContainer.m_inventory = inventory;
-        backpackContainer.m_width = inventory.m_width;
-        backpackContainer.m_height = inventory.m_height;
-        backpackContainer.m_bkg = backpack.Item.m_shared.m_icons[0];
 
         InventoryGuiPatches.BackpackIsOpen = true;
         instance.Show(backpackContainer);

--- a/AdventureBackpacks/Patches/Humanoid.cs
+++ b/AdventureBackpacks/Patches/Humanoid.cs
@@ -2,9 +2,11 @@
 using System.Linq;
 using System.Reflection.Emit;
 using System.Threading;
+using AdventureBackpacks.Components;
 using AdventureBackpacks.Extensions;
 using AdventureBackpacks.Features;
 using HarmonyLib;
+using Vapok.Common.Managers;
 
 namespace AdventureBackpacks.Patches;
 
@@ -104,7 +106,9 @@ public class HumanoidPatches
                     inventoryGui.CloseContainer();
                     InventoryGuiPatches.BackpackIsOpen = false;
                 }
-
+                
+                var backpackContainer = player.gameObject.GetComponent<Container>();
+                backpackContainer.m_inventory = new Inventory("Empty", null, 1, 1);
                 InventoryGuiPatches.BackpackEquipped = false;
             }
         }
@@ -119,12 +123,22 @@ public class HumanoidPatches
             
             if ( Player.m_localPlayer == null && !__result)
                 return;
-
+            var player = Player.m_localPlayer;
             var item = __0;
 
             if (item.IsBackpack())
             {
                 InventoryGuiPatches.BackpackEquipped = true;
+                
+                var backpackContainer = player.gameObject.GetComponent<Container>();
+
+                var backpack = item.Data().GetOrCreate<BackpackComponent>();
+                
+                var inventory = backpack.GetInventory();
+                backpackContainer.m_inventory = inventory;
+                backpackContainer.m_width = inventory.m_width;
+                backpackContainer.m_height = inventory.m_height;
+                backpackContainer.m_bkg = backpack.Item.m_shared.m_icons[0];
             }
         }
     }

--- a/AdventureBackpacks/Patches/Humanoid.cs
+++ b/AdventureBackpacks/Patches/Humanoid.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using System.Threading;
 using AdventureBackpacks.Extensions;
 using AdventureBackpacks.Features;
 using HarmonyLib;
@@ -14,6 +15,8 @@ public class HumanoidPatches
     {
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            var patchedSuccess = false;
+            
             var instrs = instructions.ToList();
 
             var counter = 0;
@@ -55,7 +58,15 @@ public class HumanoidPatches
                     //Save output of calling method to local variable 0
                     yield return LogMessage(new CodeInstruction(OpCodes.Stloc_0));
                     counter++;
+                    
+                    patchedSuccess = true;
                 }
+            }
+
+            if (!patchedSuccess)
+            {
+                AdventureBackpacks.Log.Error($"{nameof(Humanoid.UpdateEquipmentStatusEffects)} Transpiler Failed To Patch");
+                Thread.Sleep(5000);
             }
         }
     }

--- a/AdventureBackpacks/Patches/InventoryGui.cs
+++ b/AdventureBackpacks/Patches/InventoryGui.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using System.Threading;
 using AdventureBackpacks.Assets;
 using AdventureBackpacks.Components;
 using AdventureBackpacks.Configuration;
@@ -244,9 +245,15 @@ internal static class InventoryGuiPatches
         [UsedImplicitly]
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilGenerator)
         {
+            
             var instrs = instructions.ToList();
 
             var counter = 0;
+
+            var patchedHideBackpackMethod = false;
+            var patchedShowBackpackMethod = false;
+            var patchedDetectInputHideMethod = false;
+            var patchedDetectInputShowMethod = false;
 
             CodeInstruction LogMessage(CodeInstruction instruction)
             {
@@ -269,7 +276,7 @@ internal static class InventoryGuiPatches
             var menuVisibleMethod = AccessTools.DeclaredMethod(typeof(Menu), nameof(Menu.IsVisible));
             var hideMethod = AccessTools.DeclaredMethod(typeof(InventoryGui), nameof(InventoryGui.Hide));
             var showMethod = AccessTools.DeclaredMethod(typeof(InventoryGui), nameof(InventoryGui.Show));
-            var inputKeyDown = AccessTools.DeclaredMethod(typeof(Input), nameof(Input.GetKeyDown), new []{typeof(KeyCode)});
+            var zInputKeyDown = AccessTools.DeclaredMethod(typeof(ZInput), nameof(ZInput.GetKeyDown), new []{typeof(KeyCode)});
             var zInputButtonDown = AccessTools.DeclaredMethod(typeof(ZInput), nameof(ZInput.GetButtonDown), new []{typeof(string)});
 
             for (int i = 0; i < instrs.Count; ++i)
@@ -295,6 +302,9 @@ internal static class InventoryGuiPatches
                     //Patch Call Method for Hiding.
                     yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(InventoryGuiPatches), nameof(HideBackpack))));
                     counter++;
+
+                    patchedHideBackpackMethod = true;
+                    
                 } else if (i > 6 && instrs[i].opcode == OpCodes.Call && instrs[i].operand.Equals(showMethod) &&
                            instrs[i - 1].opcode == OpCodes.Ldc_I4_1 && instrs[i - 2].opcode == OpCodes.Ldnull &&
                            instrs[i - 3].opcode == OpCodes.Ldarg_0)
@@ -321,7 +331,9 @@ internal static class InventoryGuiPatches
                     //Patch Call Method for Hiding.
                     yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(InventoryGuiPatches), nameof(ShowBackpack))));
                     counter++;
-                } else if (i > 6 && instrs[i].opcode == OpCodes.Call && instrs[i].operand.Equals(inputKeyDown) && instrs[i - 1].operand.Equals((sbyte)KeyCode.Escape) && instrs[i + 2].opcode == OpCodes.Ldstr && instrs[i + 2].operand.Equals("Use"))
+
+                    patchedShowBackpackMethod = true;
+                } else if (i > 6 && instrs[i].opcode == OpCodes.Call && instrs[i].operand.Equals(zInputKeyDown) && instrs[i - 1].operand.Equals((sbyte)KeyCode.Escape) && instrs[i + 2].opcode == OpCodes.Ldstr && instrs[i + 2].operand.Equals("Use"))
                 {
 
                     //1. Output current spot.
@@ -367,6 +379,8 @@ internal static class InventoryGuiPatches
                     //10. Write Brture instruction with new label
                     yield return LogMessage(new CodeInstruction(OpCodes.Brtrue, detectHideLabel));
                     counter++;
+
+                    patchedDetectInputHideMethod = true;
 
                 } else if (i > 6 && instrs[i].opcode == OpCodes.Call && instrs[i].operand.Equals(zInputButtonDown) 
                            && instrs[i - 1].operand.Equals("Inventory") && instrs[i + 1].opcode == OpCodes.Brtrue 
@@ -415,12 +429,25 @@ internal static class InventoryGuiPatches
                     //10. Write Brture instruction with new label
                     yield return LogMessage(new CodeInstruction(OpCodes.Brtrue, detectShowLabel));
                     counter++;
+
+                    patchedDetectInputShowMethod = true;
                 }
                 else
                 {
                     yield return LogMessage(instrs[i]);
                     counter++;
                 }
+            }
+
+            if (!patchedHideBackpackMethod || !patchedShowBackpackMethod || !patchedDetectInputHideMethod ||
+                !patchedDetectInputShowMethod)
+            {
+                AdventureBackpacks.Log.Error($"InventoryGui.Update Transpiler Failed To Patch");
+                AdventureBackpacks.Log.Warning($" patchedHideBackpackMethod {patchedHideBackpackMethod}");
+                AdventureBackpacks.Log.Warning($" patchedShowBackpackMethod {patchedShowBackpackMethod}");
+                AdventureBackpacks.Log.Warning($" patchedDetectInputHideMethod {patchedDetectInputHideMethod}");
+                AdventureBackpacks.Log.Warning($" patchedDetectInputShowMethod {patchedDetectInputShowMethod}");
+                Thread.Sleep(5000);
             }
         }
     }
@@ -430,6 +457,7 @@ internal static class InventoryGuiPatches
     {
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            var patchedSuccess = false;
             var instrs = instructions.ToList();
 
             var counter = 0;
@@ -441,7 +469,7 @@ internal static class InventoryGuiPatches
             }
 
             var ldArgInstruction = new CodeInstruction(OpCodes.Ldarg_2);
-            var countItemsMethod = AccessTools.DeclaredMethod(typeof(Inventory), "CountItems", new[] { typeof(string), typeof(int) }); 
+            var countItemsMethod = AccessTools.DeclaredMethod(typeof(Inventory), nameof(Inventory.CountItems), new[] { typeof(string), typeof(int), typeof(bool) }); 
 
             for (int i = 0; i < instrs.Count; ++i)
             {
@@ -474,7 +502,14 @@ internal static class InventoryGuiPatches
                     //Save output of calling method to local variable 0
                     yield return LogMessage(new CodeInstruction(OpCodes.Stloc_S, instrs[i].operand));
                     counter++;
+
+                    patchedSuccess = true;
                 }
+            }
+            if (!patchedSuccess)
+            {
+                AdventureBackpacks.Log.Error($"InventoryGui.SetupRequirement Transpiler Failed To Patch");
+                Thread.Sleep(5000);
             }
         }
     }

--- a/AdventureBackpacks/Patches/ItemDrop.cs
+++ b/AdventureBackpacks/Patches/ItemDrop.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using System.Threading;
 using AdventureBackpacks.Assets;
 using AdventureBackpacks.Components;
 using HarmonyLib;
@@ -34,6 +35,8 @@ public class ItemDropPatches
         
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            var patchedSuccess = false;
+            
             var instrs = instructions.ToList();
 
             var counter = 0;
@@ -79,12 +82,20 @@ public class ItemDropPatches
                     //Output current Operation
                     yield return LogMessage(instrs[i]);
                     counter++;
+                    
+                    patchedSuccess = true;
                 } 
                 else
                 {
                     yield return LogMessage(instrs[i]);
                     counter++;
                 }
+            }
+
+            if (!patchedSuccess)
+            {
+                AdventureBackpacks.Log.Error($"{nameof(ItemDrop.ItemData.GetWeight)} Transpiler Failed To Patch");
+                Thread.Sleep(5000);
             }
         }
     }

--- a/AdventureBackpacks/Patches/Player.cs
+++ b/AdventureBackpacks/Patches/Player.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Emit;
+using System.Threading;
 using HarmonyLib;
 
 namespace AdventureBackpacks.Patches;
@@ -60,6 +61,8 @@ public class PlayerPatches
         
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            var patchedSuccess = false;
+            
             var instrs = instructions.ToList();
 
             var counter = 0;
@@ -104,7 +107,15 @@ public class PlayerPatches
                     //Save output of calling method to local variable 0
                     yield return LogMessage(new CodeInstruction(OpCodes.Stloc_S, instrs[i].operand));
                     counter++;
+                    
+                    patchedSuccess = true;
                 }
+            }
+            
+            if (!patchedSuccess)
+            {
+                AdventureBackpacks.Log.Error($"{nameof(Player.HaveRequirementItems)} Transpiler Failed To Patch");
+                Thread.Sleep(5000);
             }
         }
     }
@@ -115,6 +126,7 @@ public class PlayerPatches
         
         public static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
         {
+            var patchedSuccess = false;
             var instrs = instructions.ToList();
 
             var counter = 0;
@@ -159,7 +171,15 @@ public class PlayerPatches
                     //Save output of calling method to local variable 0
                     yield return LogMessage(new CodeInstruction(OpCodes.Stloc_3));
                     counter++;
+                    
+                    patchedSuccess = true;
                 }
+            }
+            
+            if (!patchedSuccess)
+            {
+                AdventureBackpacks.Log.Error($"{nameof(Player.ConsumeResources)} Transpiler Failed To Patch");
+                Thread.Sleep(5000);
             }
         }
     }

--- a/AdventureBackpacks/Patches/Player.cs
+++ b/AdventureBackpacks/Patches/Player.cs
@@ -8,6 +8,15 @@ namespace AdventureBackpacks.Patches;
 
 public class PlayerPatches
 {
+    [HarmonyPatch(typeof(Player), nameof(Player.Awake))]
+    static class PlayerAwakePatch
+    {
+        static void Postfix(Player __instance)
+        {
+            __instance.gameObject.AddComponent<Container>();
+        }
+    }
+
     public static int AdjustCountIfEquipped(Player player, Piece.Requirement resource, int itemCount)
     {
         var num = itemCount;

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.22.0")]
-[assembly: AssemblyFileVersion("1.6.22.0")]
+[assembly: AssemblyVersion("1.6.23.0")]
+[assembly: AssemblyFileVersion("1.6.23.0")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # 1.6.23 - Updates and Compatibilities
 * Fixed the Inventory Input Control that was broken.
 * Added in logging and warning messages when Transpilers don't patch.
-* Added in Container compatibility for mods (like AzuCraftyBoxes) that would access containers.
+* Added in Container compatibility for mods (like AzuCraftyBoxes) that would access containers. (GitHub Issue #110)
   * This places a Container component on the Player(Clone) that will always contain the inventory of the EQUIPPED backpack
   * This would allow Craft from Containers (assuming no code changes needed on other mods) to access that inventory.
+* Added Configuration to Show/Hide the Backpack Status Effect (GitHub Issue #104)
+* Added Configuration to give Backpack Status Effect a Custom Name (GitHub Issue #104)
 
 # 1.6.22 - Hildir's Bug Fixing
 * Fixes Item Requirement Count Method - Missed 1 method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.6.23 - Updates and Compatibilities
+* Fixed the Inventory Input Control that was broken.
+* Added in logging and warning messages when Transpilers don't patch.
+* Added in Container compatibility for mods (like AzuCraftyBoxes) that would access containers.
+  * This places a Container component on the Player(Clone) that will always contain the inventory of the EQUIPPED backpack
+  * This would allow Craft from Containers (assuming no code changes needed on other mods) to access that inventory.
+
 # 1.6.22 - Hildir's Bug Fixing
 * Fixes Item Requirement Count Method - Missed 1 method.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.22",
+  "version_number": "1.6.23",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.23 - Updates and Compatibilities
* Fixed the Inventory Input Control that was broken.
* Added in logging and warning messages when Transpilers don't patch.
* Added in Container compatibility for mods (like AzuCraftyBoxes) that would access containers. (GitHub Issue #110)
  * This places a Container component on the Player(Clone) that will always contain the inventory of the EQUIPPED backpack
  * This would allow Craft from Containers (assuming no code changes needed on other mods) to access that inventory.
* Added Configuration to Show/Hide the Backpack Status Effect (GitHub Issue #104)
* Added Configuration to give Backpack Status Effect a Custom Name (GitHub Issue #104)