### PR TITLE
Release 1.6.24 - Unequip and Equip get called multiple times during startup

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -28,7 +28,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.23";
+        private const string _version = "1.6.24";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/Patches/Humanoid.cs
+++ b/AdventureBackpacks/Patches/Humanoid.cs
@@ -6,6 +6,8 @@ using AdventureBackpacks.Components;
 using AdventureBackpacks.Extensions;
 using AdventureBackpacks.Features;
 using HarmonyLib;
+using UnityEngine.EventSystems;
+using UnityEngine.SceneManagement;
 using Vapok.Common.Managers;
 
 namespace AdventureBackpacks.Patches;
@@ -84,7 +86,10 @@ public class HumanoidPatches
             
             if ( Player.m_localPlayer == null)
                 return;
-            
+
+            if (SceneManager.GetActiveScene().name.Equals("start"))
+                return;
+
             var player = Player.m_localPlayer;
 
             var item = __0;
@@ -123,6 +128,10 @@ public class HumanoidPatches
             
             if ( Player.m_localPlayer == null && !__result)
                 return;
+            
+            if (SceneManager.GetActiveScene().name.Equals("start"))
+                return;
+            
             var player = Player.m_localPlayer;
             var item = __0;
 

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.23.0")]
-[assembly: AssemblyFileVersion("1.6.23.0")]
+[assembly: AssemblyVersion("1.6.24.0")]
+[assembly: AssemblyFileVersion("1.6.24.0")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.6.24 - Updates and Compatibilities
+* Fixing a Player Load error on Startup when wearing a backpack.
+
 # 1.6.23 - Updates and Compatibilities
 * Fixed the Inventory Input Control that was broken.
 * Added in logging and warning messages when Transpilers don't patch.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.23",
+  "version_number": "1.6.24",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
In the start scene, equip and unequip methods are called multiple times in order to show the model in the character select screen.

I don't want my backpack operations running in the start scene since a large portion of the functionality isn't initialized yet.

This is what was causing the error.  This now detects for start scene and ignores backpack functions.