### PR TITLE
Release 1.6.25 - 

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -28,7 +28,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.24";
+        private const string _version = "1.6.25";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/Patches/Container.cs
+++ b/AdventureBackpacks/Patches/Container.cs
@@ -1,4 +1,9 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Threading;
 using HarmonyLib;
+using UnityEngine;
 
 namespace AdventureBackpacks.Patches;
 
@@ -17,4 +22,67 @@ public static class ContainerPatches
         }
     }
 
+    [HarmonyPatch(typeof(Container), nameof(Container.Awake))]
+    static class ContainerAwakePatch
+    {
+        static void UpdateZDO(Container instance, ZNetView nview)
+        {
+            if (instance.name.Equals("Player(Clone)"))
+            {
+                nview.GetZDO().Set("creator".GetStableHashCode(),1L);
+            }
+                
+        }
+        
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilGenerator)
+        {
+            var patchedSuccess = false;
+            
+            var instrs = instructions.ToList();
+
+            var counter = 0;
+
+            CodeInstruction LogMessage(CodeInstruction instruction)
+            {
+                AdventureBackpacks.Log.Debug($"IL_{counter}: Opcode: {instruction.opcode} Operand: {instruction.operand}");
+                return instruction;
+            }
+
+            var invokeRepeatingMethod = AccessTools.DeclaredMethod(typeof(MonoBehaviour), nameof(MonoBehaviour.InvokeRepeating), new []{typeof(string), typeof(float), typeof(float)});
+            var nviewField = AccessTools.DeclaredField(typeof(Container),nameof(Container.m_nview));
+
+            for (int i = 0; i < instrs.Count; ++i)
+            {
+                if (i > 5 && instrs[i].opcode == OpCodes.Ret && instrs[i-1].opcode == OpCodes.Call && instrs[i-1].operand.Equals(invokeRepeatingMethod))
+                {
+                    //Container this (arg #1)
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    counter++;
+                    
+                    //Container this (for arg #2)
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);
+                    counter++;
+                    
+                    //Container Field nview (arg #2)
+                    yield return new CodeInstruction(OpCodes.Ldfld,nviewField);
+                    counter++;
+          
+                    //Patch Calling Method
+                    yield return LogMessage(new CodeInstruction(OpCodes.Call, AccessTools.DeclaredMethod(typeof(ContainerAwakePatch), nameof(UpdateZDO))));
+                    counter++;
+
+                    patchedSuccess = true;
+                }
+
+                yield return LogMessage(instrs[i]);
+                counter++;
+            }
+            
+            if (!patchedSuccess)
+            {
+                AdventureBackpacks.Log.Error($"Container.Awake Transpiler Failed To Patch");
+                Thread.Sleep(5000);
+            }
+        }
+    }
 }

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.24.0")]
-[assembly: AssemblyFileVersion("1.6.24.0")]
+[assembly: AssemblyVersion("1.6.25.0")]
+[assembly: AssemblyFileVersion("1.6.25.0")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
   * This is needed to prevent other mods from having to make specific updates for this mod.
   * AzuCraftyBoxes is now fully supported with Adventure Backpacks when using the Equipped Backpack
   * Craft From Containers needs 1 update in order to work (They need to not check for Piece component)
+* Fixes a Compatibility issue with Valheim+ Where Transpilers were fighting for attention.
 
 # 1.6.24 - Updates and Compatibilities
 * Fixing a Player Load error on Startup when wearing a backpack.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.6.25 - Container Checking for Mod Compatibility
+* Made changes will allow the Container to be recognized as "player built"
+  * This is needed to prevent other mods from having to make specific updates for this mod.
+  * AzuCraftyBoxes is now fully supported with Adventure Backpacks when using the Equipped Backpack
+  * Craft From Containers needs 1 update in order to work (They need to not check for Piece component)
+
 # 1.6.24 - Updates and Compatibilities
 * Fixing a Player Load error on Startup when wearing a backpack.
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
 * Project Auga
 * Quick Stack Store
 * Auto Split Stack
+* AzuCraftyBoxes
 * Multi-User-Chests
 * Fast Item Transfer
 * Equipment and Quick Slots

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.24",
+  "version_number": "1.6.25",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.25 - Container Checking for Mod Compatibility
* Made changes will allow the Container to be recognized as "player built"
  * This is needed to prevent other mods from having to make specific updates for this mod.
  * AzuCraftyBoxes is now fully supported with Adventure Backpacks when using the Equipped Backpack
  * Craft From Containers needs 1 update in order to work (They need to not check for Piece component)
* Fixes a Compatibility issue with Valheim+ Where Transpilers were fighting for attention.