### PR TITLE
Fixing the backpack container bug and release 1.6.27

### DIFF
--- a/AdventureBackpacks/AdventureBackpacks.cs
+++ b/AdventureBackpacks/AdventureBackpacks.cs
@@ -28,7 +28,7 @@ namespace AdventureBackpacks
         //Module Constants
         private const string _pluginId = "vapok.mods.adventurebackpacks";
         private const string _displayName = "Adventure Backpacks";
-        private const string _version = "1.6.26";
+        private const string _version = "1.6.27";
         
         //Interface Properties
         public string PluginId => _pluginId;

--- a/AdventureBackpacks/AdventureBackpacks.csproj
+++ b/AdventureBackpacks/AdventureBackpacks.csproj
@@ -56,6 +56,7 @@
         <Reference Include="System" />
         <Reference Include="System.Core" />
         <Reference Include="System.Data" />
+        <Reference Include="System.Net.Http" />
         <Reference Include="System.Xml" />
         <Reference Include="UnityEngine">
           <HintPath>..\..\References\BepInEx\5.4.2101\unstripped_corlib\UnityEngine.dll</HintPath>
@@ -78,8 +79,11 @@
         <Reference Include="UnityEngine.UI">
           <HintPath>..\..\References\BepInEx\5.4.2101\unstripped_corlib\UnityEngine.UI.dll</HintPath>
         </Reference>
-        <Reference Include="Vapok.Common">
-          <HintPath>..\..\References\Vapok.Common\Vapok.Common.dll</HintPath>
+        <Reference Include="Vapok.Valheim.Common, Version=0.217.14.0, Culture=neutral, processorArchitecture=MSIL">
+          <HintPath>..\packages\Vapok.Valheim.Common.1.3.21714\lib\net462\Vapok.Valheim.Common.dll</HintPath>
+        </Reference>
+        <Reference Include="YamlDotNet, Version=12.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+          <HintPath>..\packages\YamlDotNet.12.3.1\lib\net45\YamlDotNet.dll</HintPath>
         </Reference>
     </ItemGroup>
     <ItemGroup>

--- a/AdventureBackpacks/Components/BackpackComponent.cs
+++ b/AdventureBackpacks/Components/BackpackComponent.cs
@@ -28,6 +28,15 @@ namespace AdventureBackpacks.Components
             return _backpackInventory;
         }
 
+        public void UpdateContainerSizing(Container backpackContainer)
+        {
+            var inventory = GetInventory();
+            backpackContainer.m_inventory = inventory;
+            backpackContainer.m_width = inventory.m_width;
+            backpackContainer.m_height = inventory.m_height;
+            backpackContainer.m_bkg = Item.m_shared.m_icons[0];
+        }
+
         public string Serialize()
         {
             _log.Debug($"[Serialize()] Starting..");

--- a/AdventureBackpacks/Extensions/PlayerExtensions.cs
+++ b/AdventureBackpacks/Extensions/PlayerExtensions.cs
@@ -18,6 +18,20 @@ public static class PlayerExtensions
         return player.m_shoulderItem.IsBackpack();
     }
 
+    public static bool IsThisBackpackEquipped(this Player player, ItemDrop.ItemData itemData )
+    {
+        if (player == null || player.GetInventory() == null)
+            return false;
+            
+        if (player.m_shoulderItem == null)
+            return false;
+
+        if (!player.m_shoulderItem.IsBackpack())
+            return false;
+        
+        return player.m_shoulderItem.Equals(itemData);
+    }
+
     public static BackpackComponent GetEquippedBackpack(this Player player)
     {
         if (player == null || player.GetInventory() == null)

--- a/AdventureBackpacks/ILRepack.targets
+++ b/AdventureBackpacks/ILRepack.targets
@@ -3,7 +3,9 @@
     <Target Name="ILRepacker" AfterTargets="Build">
         <ItemGroup>
             <InputAssemblies Include="$(TargetPath)" />
-            <InputAssemblies Include="$(OutputPath)\Vapok.Common.dll" />
+            <InputAssemblies Include="$(OutputPath)\Vapok.Valheim.Common.dll" />
+            <InputAssemblies Include="$(OutputPath)\YamlDotNet.dll" />
+            <InputAssemblies Include="$(OutputPath)\ServerSync.dll" />
             <LibraryPath Include="$(OutputPath)" />
         </ItemGroup>
         <ILRepack Parallel="true" DebugInfo="true" Internalize="true" InputAssemblies="@(InputAssemblies)" OutputFile="$(TargetPath)" TargetKind="SameAsPrimaryAssembly" LibraryPath="@(LibraryPath)" />

--- a/AdventureBackpacks/Patches/Humanoid.cs
+++ b/AdventureBackpacks/Patches/Humanoid.cs
@@ -140,14 +140,8 @@ public class HumanoidPatches
                 InventoryGuiPatches.BackpackEquipped = true;
                 
                 var backpackContainer = player.gameObject.GetComponent<Container>();
-
                 var backpack = item.Data().GetOrCreate<BackpackComponent>();
-                
-                var inventory = backpack.GetInventory();
-                backpackContainer.m_inventory = inventory;
-                backpackContainer.m_width = inventory.m_width;
-                backpackContainer.m_height = inventory.m_height;
-                backpackContainer.m_bkg = backpack.Item.m_shared.m_icons[0];
+                backpack.UpdateContainerSizing(backpackContainer);
             }
         }
     }

--- a/AdventureBackpacks/Patches/InventoryGui.cs
+++ b/AdventureBackpacks/Patches/InventoryGui.cs
@@ -26,11 +26,23 @@ internal static class InventoryGuiPatches
         [UsedImplicitly]
         static void Postfix(InventoryGui __instance)
         {
+            if ( Player.m_localPlayer == null)
+                return;
+            var player = Player.m_localPlayer;
+            
             if (__instance.m_craftUpgradeItem != null && __instance.m_craftUpgradeItem.IsBackpack())
             {
                 var backpack = __instance.m_craftUpgradeItem.Data().Get<BackpackComponent>();
+                if (backpack == null)
+                    return;
+                
+                var backpackContainer = player.gameObject.GetComponent<Container>();
                 backpack?.Load();
-                Player.m_localPlayer.UpdateEquipmentStatusEffects();
+                
+                if (player.IsThisBackpackEquipped(backpack.Item))
+                    backpack?.UpdateContainerSizing(backpackContainer);
+                
+                player.UpdateEquipmentStatusEffects();
             }
         }
     }
@@ -447,6 +459,7 @@ internal static class InventoryGuiPatches
                 AdventureBackpacks.Log.Warning($" patchedShowBackpackMethod {patchedShowBackpackMethod}");
                 AdventureBackpacks.Log.Warning($" patchedDetectInputHideMethod {patchedDetectInputHideMethod}");
                 AdventureBackpacks.Log.Warning($" patchedDetectInputShowMethod {patchedDetectInputShowMethod}");
+                AdventureBackpacks.Log.Error($"Please inform Mod Author.");
                 Thread.Sleep(5000);
             }
         }

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.26.0")]
-[assembly: AssemblyFileVersion("1.6.26.0")]
+[assembly: AssemblyVersion("1.6.27.0")]
+[assembly: AssemblyFileVersion("1.6.27.0")]

--- a/AdventureBackpacks/packages.config
+++ b/AdventureBackpacks/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ILRepack.Lib.MSBuild.Task" version="2.0.18.2" targetFramework="net462" />
+  <package id="Vapok.Valheim.Common" version="1.3.21714" targetFramework="net462" />
+  <package id="YamlDotNet" version="12.3.1" targetFramework="net462" />
 </packages>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.6.27 - Bug Fix
+* Fixed: In a rare case, when a bag is upgraded, and then you die before unequipping your bag, it can potentially lose the contents of the backpack.
+  * This is fixed in this version.
+
 # 1.6.26 - Hotfix to address Critical Crashing Bug
 * Turns out adding a container on Players, make them interactable which crashes the player object.
   * Disabled the interaction function on containers when the container is Player(Clone)
@@ -8,6 +12,9 @@
   * AzuCraftyBoxes is now fully supported with Adventure Backpacks when using the Equipped Backpack
   * Craft From Containers needs 1 update in order to work (They need to not check for Piece component)
 * Fixes a Compatibility issue with Valheim+ Where Transpilers were fighting for attention.
+
+<details>
+<summary><b>Changelog History</b> (<i>click to expand</i>)</summary>
 
 # 1.6.24 - Updates and Compatibilities
 * Fixing a Player Load error on Startup when wearing a backpack.
@@ -269,3 +276,5 @@
    * Adventure Backpacks will seamlessly convert Jotunn Backpacks into new Adventure Backpacks.
    * As such, Jotunn Backpacks is incompatible with Adventure Backpacks
      * Utilizing the same Prefab Name, to get technical.
+
+</details>

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.6.26",
+  "version_number": "1.6.27",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.6.27 - Bug Fix
* Fixed: In a rare case, when a bag is upgraded, and then you die before unequipping your bag, it can potentially lose the contents of the backpack.
  * This is fixed in this version.