### PR TITLE
Update 1.9.7

### DIFF
--- a/AdventureBackpacks/Assets/Effects/EffectsBase.cs
+++ b/AdventureBackpacks/Assets/Effects/EffectsBase.cs
@@ -5,7 +5,6 @@ using AdventureBackpacks.Configuration;
 using AdventureBackpacks.Extensions;
 using BepInEx.Configuration;
 using Vapok.Common.Managers.Configuration;
-using Vapok.Common.Shared;
 
 namespace AdventureBackpacks.Assets.Effects;
 
@@ -20,6 +19,7 @@ public abstract class EffectsBase
     private string _description;
     private StatusEffect _statusEffect;
     private bool _isSetItemStatusEffect;
+    private bool _effectSwitch = true;
 
     public EffectsBase(string effectName, string effectDesc, bool IsItemSetStatusEffect = false)
     {
@@ -60,7 +60,7 @@ public abstract class EffectsBase
         statusEffect = _statusEffect;
         return statusEffect != null && IsEffectActive(item);
     }
-
+    
     public virtual bool IsEffectActive(Humanoid human)
     {
         if (human is Player player)
@@ -94,6 +94,27 @@ public abstract class EffectsBase
         return false;
     }
 
+    public virtual void ToggleEffect()
+    {
+        
+    }
+    
+    public virtual void ToggleEffectSwitch()
+    {
+        _effectSwitch = !_effectSwitch;
+    }
+    
+    public virtual void SetEffectSwitch(bool switchValue)
+    {
+        _effectSwitch = switchValue;
+    }
+    
+    public virtual bool CurrectSwitchSetting()
+    {
+        return _effectSwitch;
+    }
+
+    
     public virtual bool IsEffectActive(ItemDrop.ItemData itemData)
     {
         if (!EnabledEffect.Value)
@@ -120,7 +141,7 @@ public abstract class EffectsBase
         return false;
     }
     
-    public void RegisterEffectConfiguration()
+    public virtual void RegisterEffectConfiguration()
     {
         BiomeQualityLevels = new();
         

--- a/AdventureBackpacks/Assets/Factories/EffectsFactory.cs
+++ b/AdventureBackpacks/Assets/Factories/EffectsFactory.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using AdventureBackpacks.API;
 using AdventureBackpacks.Assets.Effects;
 using Vapok.Common.Abstractions;
@@ -29,10 +30,11 @@ public class EffectsFactory : FactoryBase
     
     private static HashSet<EffectsBase> _externalEffects = new();
     private static HashSet<EffectsBase> _allEffects = new();
+    public static EffectsFactory Instance;
     
     public EffectsFactory(ILogIt logger, ConfigSyncBase configs) : base(logger, configs)
     {
-    
+        Instance = this;
     }
 
     public static HashSet<StatusEffect> GetRegisteredEffects()
@@ -91,5 +93,10 @@ public class EffectsFactory : FactoryBase
                     break;
             }
         }
+    }
+
+    public void ToggleEffects()
+    {
+        _effectList.Values.ToList().ForEach(x => x.ToggleEffect());
     }
 }

--- a/AdventureBackpacks/Configuration/ConfigRegistry.cs
+++ b/AdventureBackpacks/Configuration/ConfigRegistry.cs
@@ -11,8 +11,6 @@ namespace AdventureBackpacks.Configuration
         //Configuration Entry Privates
         internal static ConfigEntry<KeyboardShortcut> HotKeyOpen;
         internal static ConfigEntry<KeyboardShortcut> HotKeyDrop;
-        internal static ConfigEntry<KeyboardShortcut> WisplightKeyToggle;
-        internal static ConfigEntry<bool> WisplightBiomeLogic;
         internal static ConfigEntry<bool> OpenWithInventory;
         internal static ConfigEntry<bool> OpenWithHoverInteract;
         internal static ConfigEntry<bool> CloseInventory;
@@ -42,16 +40,7 @@ namespace AdventureBackpacks.Configuration
                 new ConfigDescription("Hotkey to quickly drop backpack while on the run.",
                     null,
                     new ConfigurationManagerAttributes { Order = 1 }),ref HotKeyDrop);
-            
-            UnsyncedConfig("Local Config", "Wisplight Effect Toggle", new KeyboardShortcut(KeyCode.L),
-                new ConfigDescription("Hotkey to turn Wisplight on and off",
-                    null,
-                    new ConfigurationManagerAttributes { Order = 1 }),ref WisplightKeyToggle);
-            
-            UnsyncedConfig("Local Config", "Wisplight Biome Logic", true,
-                new ConfigDescription("If enabled, the Wisplight will automatically turn on when entering Mistlands, and turn off when exiting.",
-                    null, new ConfigurationManagerAttributes { Order = 3 }), ref WisplightBiomeLogic);
-            
+           
             UnsyncedConfig("Local Config", "Open with Inventory", false,
                 new ConfigDescription("If enabled, both backpack and inventory will open when Inventory is opened.",
                     null, new ConfigurationManagerAttributes { Order = 3 }),ref OpenWithInventory);
@@ -71,8 +60,6 @@ namespace AdventureBackpacks.Configuration
             UnsyncedConfig("Local Config", "Replace Shader", true,
                 new ConfigDescription("Toggle To use the Material Shader Replacer (Requires Game Restart)",
                     null, new ConfigurationManagerAttributes { Order = 1 }), ref ReplaceShader);
-            
-
         }
     }
     

--- a/AdventureBackpacks/Features/QuickTransfer.cs
+++ b/AdventureBackpacks/Features/QuickTransfer.cs
@@ -3,10 +3,8 @@ using AdventureBackpacks.Extensions;
 using BepInEx.Bootstrap;
 using BepInEx.Configuration;
 using HarmonyLib;
-using PlayFab.Internal;
 using UnityEngine;
 using Vapok.Common.Managers.Configuration;
-using Vapok.Common.Shared;
 
 namespace AdventureBackpacks.Features;
 

--- a/AdventureBackpacks/Features/Utilities.cs
+++ b/AdventureBackpacks/Features/Utilities.cs
@@ -1,6 +1,3 @@
-using System.Linq;
-using System.Reflection;
-using Jotunn.Managers;
 using Jotunn.Utils;
 using UnityEngine;
 

--- a/AdventureBackpacks/Properties/AssemblyInfo.cs
+++ b/AdventureBackpacks/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 #if ! API
-[assembly: AssemblyVersion("1.9.6.0")]
-[assembly: AssemblyFileVersion("1.9.6.0")]
+[assembly: AssemblyVersion("1.9.7.0")]
+[assembly: AssemblyFileVersion("1.9.7.0")]
 #else
 [assembly: AssemblyVersion("1.1.0")]
 [assembly: AssemblyFileVersion("1.1.0")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-# 1.9.6 - TIL Wisplights are Desired 
+# 1.9.7 - Item Loss Issue - Update to Dedicated Server Strictness and Wisplight Config Changes
+* It has been identified that major item data loss can occur if two clients are on a dedicated server, but only one client has Adventure Backpacks installed. The client without the mod can create dataloss, including the contents of a backpack.
+  * To safeguard against this, I have enabled JVL Network Compatibility to enforce that all clients must use Adventure Backpacks.
+  * This will require Adventure Backpacks, along with JVL and Yaml mods to be installed on dedicated servers.
+  * Additionally all clients and servers must be using the same version as of this update.
+* Reorganized Configuration Settings for Wisplight, now found under "Wisplight Client Settings" under the Effect
+  * This is prep work for providing similar functionality later on for other effects.
+  * This might result in resetting of your client config for these settings.
+* Updates to ReadMe
+
+# 1.9.6 - TIL Wisplights are Desired
 * Added a new config setting called Wisplight Biome Logic
   * This can be disabled to allow the wisplight to be used in any biome
   * You're welcome schrodingerspsycho <3

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
 * Install Adventure Backpacks into it's own FOLDER inside of the `BepInEx/plugins` folder.
   * Create a folder called `Translations` and ensure all Translation files are stored in there.
     * Translations files should be named `AdventureBackpacks.<language key>.json`
-* Adventure Backpacks is a client-side and server-side mod.
+* Adventure Backpacks is a client-side **AND** server-side mod and should be installed on both.
   * If using on Dedicated Servers:
-    * Configuration Lock and Sync is available and disabled by default.
-      * Enabling Locked and Synced Configs will require server restart.
-      * All other settings will be synced to connected clients, and server configs will be enforced.
-
+    * Configuration Lock and Sync is automatically enabled for configured Admins
+      * All Syncable settings will be synced to connected clients, and server configs will be enforced.
+      * Admins can change server configs using a Configuration Management mod.
+  * Network Compatibility Enforcement is enabled.
+    * This is to prevent data loss on a dedicated server if one client is running the mod, but another client isn't. In particular, you could lose your backpacks and everything in them if someone opens a chest and doesn't have the mod.
 ---
 
 ## Gear Introduced In This Mod
-* The 6 new backpacks are:
+* The 6 Original Adventure Backpacks are:
     * **Satchel** - _A small backpack capable of holding things._
     * **Rugged Backpack**  - _A rugged backpack, complete with buckles and fine leather straps._
     * **Bloodbag Wetpack** - _A durable backpack sealed using waterproof blood bags._
@@ -89,7 +90,7 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
     * Swamp Key for Crypts
 * Optional Right Click Quick Transfer (Fast Item Transfer)
   * Allows single right-click transfer of an item/stack of items between Player Inventory and any Open Container
-  * This is the same functionality that's available as the stand-alone mod **Fast Item Transfer**
+  * This is the same functionality that's available as the stand-alone mod **Fast Item Transfer** which is disabled when installed with Adventure Backpacks
 * Outward Run Away Mode
   * Pressing the Quick Drop keybind (default is `Y`), will immediately release the equipped backpack and drop it behind the player on the ground.
   * This feature is optional, and is disabled out of the box.
@@ -105,7 +106,7 @@ learn how to make your very own, Adventure Backpacks!  Go forth and wander, ye w
   * Waterproof
   * Slow Fall
   * Demister (Wisplight effect that clears mist in Mistlands)
-    * Config Settings For Demister
+    * Config Settings For Demister found in "Wisplight Client Settings"
       * Toggle Wisplight with Keybind 
         * Default: "L" key
       * Wisplight Biome Logic to automatically turn off Wisplight when not in Mistlands.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "AdventureBackpacks",
-  "version_number": "1.9.6",
+  "version_number": "1.9.7",
   "website_url": "https://github.com/Vapok/AdventureBackpacks",
   "description": "A Valheim Mod to add a catalogue of Adventuring Backpacks to the Game. These packs will grow and become more useful as the game progresses.",
   "dependencies": [


### PR DESCRIPTION
# 1.9.7 - Item Loss Issue - Update to Dedicated Server Strictness and Wisplight Config Changes
* It has been identified that major item data loss can occur if two clients are on a dedicated server, but only one client has Adventure Backpacks installed. The client without the mod can create dataloss, including the contents of a backpack.
  * To safeguard against this, I have enabled JVL Network Compatibility to enforce that all clients must use Adventure Backpacks.
  * This will require Adventure Backpacks, along with JVL and Yaml mods to be installed on dedicated servers.
  * Additionally all clients and servers must be using the same version as of this update.
* Reorganized Configuration Settings for Wisplight, now found under "Wisplight Client Settings" under the Effect
  * This is prep work for providing similar functionality later on for other effects.
  * This might result in resetting of your client config for these settings.
* Updates to ReadMe